### PR TITLE
IntelliJ plugin to bundle jgrapht dependency

### DIFF
--- a/infinitest-intellij/assembly.xml
+++ b/infinitest-intellij/assembly.xml
@@ -14,6 +14,7 @@
                 <include>org.infinitest:infinitest-intellij</include>
                 <include>com.google.guava:guava</include>
                 <include>javassist:javassist</include>
+                <include>org.jgrapht:jgrapht-jdk1.5</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
Infinitest built from the master branch fails for me due to failing to find jgrapht (IntelliJ IDEA 9.0.3 CE).

Patch is to add the missing library to the maven assembly plugin config.
