### PR TITLE
Generate an Eclipse plugin's manifest in a location expected by Eclipse

### DIFF
--- a/infinitest-eclipse/pom.xml
+++ b/infinitest-eclipse/pom.xml
@@ -129,7 +129,7 @@
 								<descriptor>src/main/assembly/assembly-plugin.xml</descriptor>
 							</descriptors>
 							<archive>
-								<manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile>
+								<manifestFile>META-INF/MANIFEST.MF</manifestFile>
 							</archive>
 						</configuration>
 					</execution>
@@ -171,6 +171,7 @@
 						<Embed-Directory>lib</Embed-Directory>
 						<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
 					</instructions>
+					<manifestLocation>META-INF/</manifestLocation>
 				</configuration>
 				<executions>
 					<execution>
@@ -181,6 +182,13 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<manifestFile>${baseDir}/META-INF/MANIFEST.MF</manifestFile>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
By default, Eclipse expects plugin's manifest in
META-INF/MANIFEST.MF file. To make it easier to develop Eclipse plugin
within Eclipse itself, Bundle plugin generates manifest under the
META-INF/ forlder in project's root.

JAR and Assembly plugins' configuration adjusted accordingly.

Signed-off-by: Mykola Nikishov mn@mn.com.ua
