### PR TITLE
Added listeners to the testng-configuration

### DIFF
--- a/infinitest-runner/src/main/java/org/infinitest/TestNGConfiguration.java
+++ b/infinitest-runner/src/main/java/org/infinitest/TestNGConfiguration.java
@@ -22,17 +22,13 @@
  */
 package org.infinitest;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import org.testng.xml.XmlSuite;
 
 /** Provides testNG-settings. Just a data-provider, no logic here. */
 public class TestNGConfiguration
 {
     private String excludedGroups;
     private String groups;
-    private List<XmlSuite> suite;
     private List<Object> listeners;
 
     public void setExcludedGroups(String excludedGroups)
@@ -53,18 +49,6 @@ public class TestNGConfiguration
     public String getGroups()
     {
         return groups;
-    }
-
-    public List<XmlSuite> getSuite()
-    {
-        return suite;
-    }
-
-    public void setSuite(XmlSuite suite)
-    {
-        List<XmlSuite> suites = new ArrayList<XmlSuite>();
-        suites.add(suite);
-        this.suite = suites;
     }
 
     public List<Object> getListeners()

--- a/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
+++ b/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
@@ -31,20 +31,16 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.testng.xml.XmlSuite;
-
 public class TestNGConfigurator
 {
     private static final String SUFFIX = "\\s?=\\s?(.+)";
     private static final String PREFIX = "^\\s*#+\\s?";
     private static final String EXCLUDED_GROUPS = "excluded-groups";
     private static final String INCLUDED_GROUPS = "groups";
-    private static final String SUITE_XML_FILE = "suiteXmlFile";
     private static final String LISTENERS = "listeners";
     private static final Pattern EXCLUDED = Pattern.compile(PREFIX + EXCLUDED_GROUPS + SUFFIX);
     private static final Pattern INCLUDED = Pattern.compile(PREFIX + INCLUDED_GROUPS + SUFFIX);
-    private static final Pattern SUITE = Pattern.compile(PREFIX + SUITE_XML_FILE + SUFFIX);
-    private static final Pattern LISTENER = Pattern.compile(PREFIX + LISTENERS + SUFFIX);;
+    private static final Pattern LISTENER = Pattern.compile(PREFIX + LISTENERS + SUFFIX);
     private static final File FILTERFILE = new File("infinitest.filters");
 
     private final TestNGConfiguration testNGConfiguration;
@@ -138,20 +134,11 @@ public class TestNGConfigurator
             }
             else
             {
-                matcher = SUITE.matcher(line);
+                matcher = LISTENER.matcher(line);
                 if (matcher.matches())
                 {
-                    final XmlSuite suite = createSuite(matcher.group(1).trim());
-                    testNGConfiguration.setSuite(suite);
-                }
-                else
-                {
-                    matcher = LISTENER.matcher(line);
-                    if (matcher.matches())
-                    {
-                        final List<Object> listenerList = createListenerList(matcher.group(1).trim());
-                        testNGConfiguration.setListeners(listenerList);
-                    }
+                    final List<Object> listenerList = createListenerList(matcher.group(1).trim());
+                    testNGConfiguration.setListeners(listenerList);
                 }
             }
         }
@@ -170,17 +157,9 @@ public class TestNGConfigurator
             catch (final ReflectiveOperationException e)
             {
                 // unable to add this listener, just continue with the next.
+                e.printStackTrace();
             }
         }
         return listenerList;
-    }
-
-    private XmlSuite createSuite(String filename)
-    {
-        final List<String> suiteFiles = new ArrayList<String>();
-        suiteFiles.add(filename);
-        final XmlSuite suite = new XmlSuite();
-        suite.setSuiteFiles(suiteFiles);
-        return suite;
     }
 }

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/JUnit4Runner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/JUnit4Runner.java
@@ -94,27 +94,19 @@ public class JUnit4Runner implements NativeRunner
         {
             config = new TestNGConfigurator().getConfig();
         }
-        if (config.getExcludedGroups() != null)
-        {
-            core.setExcludedGroups(config.getExcludedGroups());
-        }
-        if (config.getGroups() != null)
-        {
-            core.setGroups(config.getGroups());
-        }
+        core.setExcludedGroups(config.getExcludedGroups());
+        core.setGroups(config.getGroups());
+        setListeners(core);
+    }
 
+    private void setListeners(TestNG core)
+    {
         if (config.getListeners() != null)
         {
             for (Object listener : config.getListeners())
             {
                 core.addListener(listener);
             }
-
-        }
-        // core.setTestSuites(suites) this is just the filename => parses every time
-        if (config.getSuite() != null)
-        {
-            core.setXmlSuites(config.getSuite());
         }
     }
 

--- a/infinitest-runner/src/test/java/org/infinitest/TestNGConfiguratorTest.java
+++ b/infinitest-runner/src/test/java/org/infinitest/TestNGConfiguratorTest.java
@@ -30,7 +30,6 @@ import java.io.PrintWriter;
 import java.util.List;
 
 import org.junit.Test;
-import org.testng.xml.XmlSuite;
 
 public class TestNGConfiguratorTest
 {
@@ -39,10 +38,8 @@ public class TestNGConfiguratorTest
     private static final String GROUPS = "quick";
     private static final String EXCLUDED = "slow, broken, manual";
     private static final Object LISTENERS = LISTENER1 + ", " + LISTENER2;
-    private static final String SUITEXMLFILE = "testng.xml";
     private static final String EXCLUDEDLINE = "## excluded-groups=" + EXCLUDED;
     private static final String GROUPSLINE = "## groups=" + GROUPS;
-    private static final String SUITELINE = "## suiteXmlFile=" + SUITEXMLFILE;
     private static final String LISTENERLINE = "## listeners=" + LISTENERS;
 
     @Test
@@ -126,15 +123,6 @@ public class TestNGConfiguratorTest
         assertNull(testNGConfiguration.getExcludedGroups());
         testNGConfiguration = new TestNGConfigurator(file).getConfig();
         assertNull(testNGConfiguration.getExcludedGroups());
-    }
-
-    @Test
-    public void testReadingXMLSuite() throws IOException
-    {
-        File file = createTestFile(SUITELINE);
-        TestNGConfiguration testNGConfiguration = new TestNGConfigurator(file).getConfig();
-        List<XmlSuite> suites = testNGConfiguration.getSuite();
-        assertEquals(SUITEXMLFILE, suites.get(0).getSuiteFiles().get(0));
     }
 
     @Test

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningTestNGTests.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningTestNGTests.java
@@ -25,9 +25,6 @@ package org.infinitest.testrunner;
 import static com.google.common.collect.Iterables.*;
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,7 +37,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.testng.ITestResult;
 import org.testng.reporters.JUnitXMLReporter;
-import org.testng.xml.XmlSuite;
 
 public class WhenRunningTestNGTests
 {
@@ -143,21 +139,6 @@ public class WhenRunningTestNGTests
         assertTrue(wasCalled);
     }
 
-    @Test
-    public void shouldExecuteDependingOnSuiteFile() throws IOException
-    {
-        File file = createTestngXML();
-        XmlSuite suite = new XmlSuite();
-        List<String> suiteNames = new ArrayList<String>();
-        suiteNames.add(file.getName());
-        suite.setSuiteFiles(suiteNames);
-        config.setSuite(suite);
-
-        TestResults results = runner.runTest(CLASS_UNDER_TEST);
-        assertEquals(3, size(results));
-        assertTrue(wasCalled);
-    }
-
     private class MyJUnitXMLReporter extends JUnitXMLReporter
     {
         @Override
@@ -165,30 +146,5 @@ public class WhenRunningTestNGTests
         {
             wasCalled = true;
         }
-    }
-
-    private File createTestngXML() throws IOException
-    {
-        final File file = File.createTempFile("testng", "xml");
-        file.deleteOnExit();
-        final PrintWriter writer = new PrintWriter(file);
-        try
-        {
-            writer.println("<suite>");
-            writer.println("<groups>");
-            writer.println("<run>");
-            writer.println("<exclude name=\"manual\"/>");
-            writer.println("</run>");
-            writer.println("</groups>");
-            writer.println("<listeners>");
-            writer.println("<listener class-name=\"org.infinitest.testrunner.WhenRunningTestNGTests.MyJUnitXMLReporter\" />");
-            writer.println("</listeners>");
-            writer.println("</suite>");
-        }
-        finally
-        {
-            writer.close();
-        }
-        return file;
     }
 }


### PR DESCRIPTION
Hi,

just added the possibility to add listeners to the testng-config  - same way as groups:
e.g.
# listeners=com.project.MyListener, com.project.MyOtherListener

best regards 
Matthias (who's going to add this to the docs in a minute).
