### PR TITLE
made the last pull request java 1.6 compatible

### DIFF
--- a/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
+++ b/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
@@ -154,7 +154,17 @@ public class TestNGConfigurator
             {
                 listenerList.add(Class.forName(listenername).newInstance());
             }
-            catch (final ReflectiveOperationException e)
+            catch (InstantiationException e)
+            {
+                // unable to add this listener, just continue with the next.
+                e.printStackTrace();
+            }
+            catch (IllegalAccessException e)
+            {
+                // unable to add this listener, just continue with the next.
+                e.printStackTrace();
+            }
+            catch (ClassNotFoundException e)
             {
                 // unable to add this listener, just continue with the next.
                 e.printStackTrace();


### PR DESCRIPTION
Hi,

sorry, I'm using java 1.7 already and they have this cool ReflectiveOperationException as a superclass for all those reflection-exceptions. Anyway, now the exceptions should be working with 1.6, too.
