### PR TITLE
Change to make IntelliJ plugin work with version 11

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
@@ -48,7 +48,8 @@ public class InfinitestHighlightingPassFactory implements TextEditorHighlighting
         {
             return null;
         }
-        return new InfinitestLineMarkersPass(module.getProject(), editor.getDocument());
+
+        return new InfinitestLineMarkersPass(module.getProject(), editor.getDocument(), editor.getMarkupModel());
     }
 
     public void projectOpened()

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestLineMarkersPass.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestLineMarkersPass.java
@@ -40,12 +40,14 @@ public class InfinitestLineMarkersPass extends TextEditorHighlightingPass implem
 
     private final Project project;
     private final Document document;
+    private final MarkupModel model;
 
-    protected InfinitestLineMarkersPass(Project project, Document document)
+    protected InfinitestLineMarkersPass(Project project, Document document, MarkupModel model)
     {
         super(project, document);
         this.project = project;
         this.document = document;
+        this.model = model;
     }
 
     @Override
@@ -66,7 +68,6 @@ public class InfinitestLineMarkersPass extends TextEditorHighlightingPass implem
 
     public void execute(PsiClass psiClass)
     {
-        MarkupModel model = document.getMarkupModel(project);
         clearInfinitestMarkersFrom(model);
 
         for (InnerClassFriendlyTestEvent each : IdeaInfinitestAnnotator.getInstance().getTestEvents())


### PR DESCRIPTION
Hi,

   I only made a little change and I hope it's enough.
   My only test was a really small project.

   In fact, the getMarkupModel() method has been removed from the Document object.
   Has explain in this issue : http://youtrack.jetbrains.net/issue/IDEA-78671, we have to use the Editor one.

Hope that will help.

Aurélien Thieriot
