### PR TITLE
Fix for Slow marker NullPointerException

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowTestMarkerInfo.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowTestMarkerInfo.java
@@ -52,7 +52,7 @@ public class SlowTestMarkerInfo extends AbstractMarkerInfo
         List<IResource> resources = lookup.findResourcesForClassName(testName);
         if (resources.isEmpty())
         {
-            return null;
+            return lookup.workspaceRoot();
         }
         return resources.get(0);
     }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
@@ -26,7 +26,10 @@ import static org.eclipse.core.resources.IMarker.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.infinitest.eclipse.markers.SlowTestMarkerInfo;
 import org.infinitest.eclipse.workspace.ResourceLookup;
@@ -56,6 +59,15 @@ public class WhenMarkingTestsAsSlow extends EqualityTestSupport
         IResource resource = mock(IResource.class);
         when(resourceLookup.findResourcesForClassName(TEST_NAME)).thenReturn(asList(resource));
         assertSame(resource, marker.associatedResource());
+    }
+
+    @Test
+    public void shouldFallbackToWorkspaceInSlowTest() throws CoreException
+    {
+        when(resourceLookup.findResourcesForClassName(TEST_NAME)).thenReturn(new ArrayList<IResource>());
+        IWorkspaceRoot workspaceRootResource = mock(IWorkspaceRoot.class);
+        when(resourceLookup.workspaceRoot()).thenReturn(workspaceRootResource);
+        assertSame(workspaceRootResource, marker.associatedResource());
     }
 
     @Test


### PR DESCRIPTION
In some cases, the following line throws a NullPointerException: https://github.com/infinitest/infinitest/blob/master/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/AbstractMarkerInfo.java#L38

``` java
    public IMarker createMarker(String markerId)
    {
        IMarker marker;
        try
        {
            IResource sourceFileResource = associatedResource();
            marker = sourceFileResource.createMarker(markerId);
            marker.setAttributes(attributes());
            return marker;
        }
        catch (CoreException e)
        {
            log("Error creating marker " + this, e);
            throw new RuntimeException();
        }
    }
```

`SlowTestMarkerInfo.associatedResource()` may return null when it cannot find the resource file associated with the test class. Such a behavior is not expected in `AbstractMarkerInfo`.

We fix that by returning `lookup.workspaceRoot();` instead of `null` in such a case (see associated test case).

Fixed with @fbiville, and the great help of @dgageot ;)

> Note that implementing a fallback strategy is nice, but it could also be interesting to investigate why no resource was found. I can't reproduce the error any more, it was somewhat random.
