### PR TITLE
Line Numbers in Slow Warnings thanks to Javassist (Eclipse only).

### DIFF
--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
+import org.infinitest.ClasspathProvider;
 import org.infinitest.eclipse.markers.SlowTestMarkerInfo;
 import org.infinitest.eclipse.workspace.ResourceLookup;
 import org.infinitest.testrunner.MethodStats;
@@ -43,14 +44,16 @@ public class WhenMarkingTestsAsSlow extends EqualityTestSupport
     private static final String TEST_NAME = "com.foo.TestName";
     private SlowTestMarkerInfo marker;
     private ResourceLookup resourceLookup;
+    private ClasspathProvider classpathProvider;
 
     @Before
     public void inContext()
     {
         resourceLookup = mock(ResourceLookup.class);
+        classpathProvider = mock(ClasspathProvider.class);
         MethodStats stats = new MethodStats("shouldRunSlowly");
         stats.stopTime = 5000;
-        marker = new SlowTestMarkerInfo(TEST_NAME, stats, resourceLookup);
+        marker = new SlowTestMarkerInfo(TEST_NAME, stats, resourceLookup, classpathProvider);
     }
 
     @Test
@@ -85,12 +88,12 @@ public class WhenMarkingTestsAsSlow extends EqualityTestSupport
     @Override
     protected Object createEqualInstance()
     {
-        return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunSlowly"), resourceLookup);
+        return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunSlowly"), resourceLookup, classpathProvider);
     }
 
     @Override
     protected Object createUnequalInstance()
     {
-        return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunQuickly"), resourceLookup);
+        return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunQuickly"), resourceLookup, classpathProvider);
     }
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 
+import org.infinitest.ClasspathProvider;
 import org.infinitest.eclipse.markers.MarkerInfo;
 import org.infinitest.eclipse.markers.SlowMarkerRegistry;
 import org.infinitest.eclipse.markers.SlowTestMarkerInfo;
@@ -52,7 +53,8 @@ public class WhenWatchingForSlowTests
         mockMarkerRegistry = mock(SlowMarkerRegistry.class);
         methodStats = new MethodStats("shouldRunSlowly");
         ResourceLookup resourceLookup = mock(ResourceLookup.class);
-        expectedMarker = new SlowTestMarkerInfo("MyTest", methodStats, resourceLookup);
+        ClasspathProvider classpathProvider = mock(ClasspathProvider.class);
+        expectedMarker = new SlowTestMarkerInfo("MyTest", methodStats, resourceLookup, classpathProvider);
         setSlowTestTimeLimit(2000);
         observer = new SlowTestObserver(mockMarkerRegistry, resourceLookup);
 

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
@@ -113,7 +113,7 @@ public class JavaAssistClassParser implements ClassParser
         return cachedClass.getClassFile2() == null;
     }
 
-    private CtClass getCachedClass(String className)
+    public CtClass getCachedClass(String className)
     {
         try
         {

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/AbstractTestRunner.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/AbstractTestRunner.java
@@ -123,7 +123,7 @@ abstract class AbstractTestRunner implements TestRunner
         this.environment = environment;
     }
 
-    protected RuntimeEnvironment getRuntimeEnvironment()
+    public RuntimeEnvironment getRuntimeEnvironment()
     {
         return environment;
     }

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/TestRunner.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/TestRunner.java
@@ -42,6 +42,8 @@ public interface TestRunner
 
     void setRuntimeEnvironment(RuntimeEnvironment environment);
 
+    RuntimeEnvironment getRuntimeEnvironment();
+
     void addConsoleOutputListener(ConsoleOutputListener listener);
 
     void removeConsoleOutputListener(ConsoleOutputListener listener);


### PR DESCRIPTION
Here is a proposal to enhance slow warnings by adding the line number to place the marker.
This feature is available in Eclipse only.

The main issue is to find the line number from a method name. This information is missing in a .class, but we can find the line number of an opcode (opcodes are indexed in the method scope) with Javassist reflection.

A code review and comments will be appreciated, so please, don't merge it as-it :)
This is more a Request For Comments than a Pull Request.

Fred
