### PR TITLE
Change junit4 bundle dependency so infinitest can be installed in eclipse kepler

### DIFF
--- a/infinitest-eclipse/pom.xml
+++ b/infinitest-eclipse/pom.xml
@@ -208,7 +208,7 @@
 						<Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
 						<Bundle-Vendor>infinitest.org</Bundle-Vendor>
 						<Require-Bundle>
-							org.eclipse.ui,org.eclipse.core.runtime,org.eclipse.core.resources,org.eclipse.jdt.core,org.junit4,org.eclipse.ui.ide,org.eclipse.ui.console;bundle-version="3.3.0",org.eclipse.jdt.debug.ui,org.eclipse.jface.text,org.eclipse.debug.core,org.eclipse.jdt.launching
+							org.eclipse.ui,org.eclipse.core.runtime,org.eclipse.core.resources,org.eclipse.jdt.core,org.junit;bundle-version="[4.0.0,5.0.0)",org.eclipse.ui.ide,org.eclipse.ui.console;bundle-version="3.3.0",org.eclipse.jdt.debug.ui,org.eclipse.jface.text,org.eclipse.debug.core,org.eclipse.jdt.launching
 						</Require-Bundle>
 						<Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
 						<Embed-Transitive>true</Embed-Transitive>


### PR DESCRIPTION
The bundle org.junit4 is not available in kepler anymore (see also https://bugs.eclipse.org/bugs/show_bug.cgi?id=402719). Because of this the infinitest eclipse plugin can not be installed in this version. This commit replaces the org.junit4 with a properly versioned org.junit bundle dependency where bundles are available in the eclipse orbit project.
