### PR TITLE
Make Infinitest IntelliJ plugin running on IntelliJ 13.

### DIFF
--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
@@ -38,6 +38,8 @@ import org.junit.runner.*;
 import org.mockito.*;
 import org.mockito.runners.*;
 
+import java.io.File;
+
 @RunWith(MockitoJUnitRunner.class)
 public class WhenResolvingClassPath {
 	@InjectMocks
@@ -75,7 +77,7 @@ public class WhenResolvingClassPath {
 
 		String classpath = classPathResolver.rawClasspath(project);
 
-		assertThat(classpath).isEqualTo("1.jar:2.jar");
+		assertThat(classpath).isEqualTo("1.jar" + File.pathSeparator + "2.jar");
 	}
 
 	@Test
@@ -91,7 +93,7 @@ public class WhenResolvingClassPath {
 
 		String classpath = classPathResolver.rawClasspath(project);
 
-		assertThat(classpath).isEqualTo("1.jar:2.jar:3.jar");
+		assertThat(classpath).isEqualTo("1.jar" + File.pathSeparator + "2.jar" + File.pathSeparator + "3.jar");
 	}
 
 	@Test

--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -30,6 +30,14 @@
     </resources>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptors>

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -216,11 +216,11 @@ public class IdeaModuleSettings implements ModuleSettings {
 
 	@Nullable
 	private File getSdkHomePath() {
-		Sdk projectJdk = ProjectRootManager.getInstance(module.getProject()).getProjectJdk();
-		if (projectJdk == null) {
+		Sdk projectSdk = ProjectRootManager.getInstance(module.getProject()).getProjectSdk();
+		if (projectSdk == null) {
 			return null;
 		}
 
-		return new File(projectJdk.getHomePath());
+		return new File(projectSdk.getHomePath());
 	}
 }

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/window/IdeaWindowHelper.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/window/IdeaWindowHelper.java
@@ -31,7 +31,6 @@ import javax.swing.*;
 
 import com.intellij.openapi.util.*;
 import com.intellij.openapi.wm.*;
-import com.intellij.peer.*;
 import com.intellij.ui.content.*;
 
 public class IdeaWindowHelper {
@@ -42,7 +41,7 @@ public class IdeaWindowHelper {
 
 	@SuppressWarnings("deprecation")
 	public void addPanelToWindow(JPanel rootPanel, ToolWindow window) {
-		ContentFactory contentFactory = PeerFactory.getInstance().getContentFactory();
+		ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
 		Content content = contentFactory.createContent(rootPanel, "Infinitest", false);
 		window.getContentManager().addContent(content);
 		window.setIcon(IconLoader.getIcon(WAITING_ICON_PATH));


### PR DESCRIPTION
Also, fix 2 failing tests on Windows that was relying on unix file path separator.
