### PR TITLE
Turn status bar yellow while tests are running

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceStatusFactory.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceStatusFactory.java
@@ -42,7 +42,7 @@ public class WorkspaceStatusFactory {
 
 	public static WorkspaceStatus runningTests(int remainingTests, String currentTest) {
 		String message = "Running " + stripPackageName(currentTest) + " (" + (remainingTests - 1) + " remaining)";
-		return new TooltippedStatus(message, "Current test: " + currentTest);
+		return new TooltippedWarningStatus(message, "Current test: " + currentTest);
 	}
 
 	public static WorkspaceStatus testRunFinished(Collection<String> testsRan) {
@@ -84,6 +84,18 @@ public class WorkspaceStatusFactory {
 	private static class WarningStatus extends SimpleStringStatus {
 		public WarningStatus(String message) {
 			super(message);
+		}
+
+		@Override
+		public boolean warningMessage() {
+			return true;
+		}
+	}
+
+	private static class TooltippedWarningStatus extends TooltippedStatus {
+
+		public TooltippedWarningStatus(String message, String tooltip) {
+			super(message, tooltip);
 		}
 
 		@Override

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -130,6 +130,17 @@ public class WhenShowingStatusInTheStatusBar {
 	}
 
 	@Test
+	public void shouldChangeToYellowWhenRunningTests() {
+		WorkspaceStatus runningTests = runningTests(10, "org.fakeco.MyCurrentTest");
+		presenter.statusChanged(runningTests);
+
+		verify(statusBar).setBackgroundColor(COLOR_YELLOW);
+		verify(statusBar).setTextColor(COLOR_BLACK);
+		verify(statusBar).setText(runningTests.getMessage());
+		verify(statusBar).setToolTip(runningTests.getToolTip());
+	}
+
+	@Test
 	public void shouldReportWhenAllTestsAreComplete() {
 		presenter.testCaseComplete(testFinished("Test1"));
 		presenter.testCaseComplete(testFinished("Test2"));


### PR DESCRIPTION
Hello,

I was refactoring the code and the infinitest bar was remaining green all the time. Suddenly I understood that it was because I created an endless loop and the test has never finished. So I had to go back in the history to find the change introduced the endless loop. It was about 15 minutes ago.

In this pull request I have implemented the simplest way to let the user know when the test is running bu turning the status bar yellow.

I know that we could also consider some more subtle ways which would not make the bar change its color very frequently which could become uncomfortable. We could extend infinitest introducing a timeout so that it reports a failure or a warning after it is reached during the tests are running. If you have an idea what solution would be the best I would gladly implement it too.

Regards, Dimitry
