### PR TITLE
Fixing issue #152 (Stack trace window opens and closes right after).

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/ErrorViewerResolution.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/ErrorViewerResolution.java
@@ -81,7 +81,18 @@ public class ErrorViewerResolution implements IMarkerResolution2 {
 	protected void createStackViewWith(List<StackTraceElement> stackTrace, String message) {
 		List<StackTraceElement> filteredStackTrace = stackTraceFilter.filterStack(stackTrace);
 		ResourceLookup resourceLookup = InfinitestPlugin.getInstance().getBean(ResourceLookup.class);
-		new FailureViewer(getMainShell(), message, filteredStackTrace, resourceLookup).show();
+		final FailureViewer failureViewer = new FailureViewer(getMainShell(), message, filteredStackTrace, resourceLookup);
+
+		// We use async exec here to avoid issue #152
+		// Using asyncExec allows to open the FailerViewer after main shell have
+		// been reactivated
+		Display.getDefault().asyncExec(new Runnable() {
+			@Override
+			public void run() {
+				failureViewer.show();
+			}
+		});
+
 	}
 
 	private Shell getMainShell() {


### PR DESCRIPTION
The issue was caused by main workbench shell being reactivated when
QuickFixDialog is closed.
The reactivation of the main shell deactivated the FailureViewer shell
triggering the attached DialogDeactivationDisposer which in turned
closed the FailureViewer.

Using asyncExec allows to open the FailerViewer after main shell have
been reactivated