### PR TITLE
Use mockito spy to allow partial mocking of object under test.

### DIFF
--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/plugin/launcher/WhenTestRunCompleted.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/plugin/launcher/WhenTestRunCompleted.java
@@ -53,7 +53,7 @@ public class WhenTestRunCompleted {
 
 		TestControl mockTestControl = mock(TestControl.class);
 
-		presenter = new InfinitestPresenter(mockResultCollector, mockCore, mockView, mockTestControl, new FakeInfinitestAnnotator());
+		presenter = spy(new InfinitestPresenter(mockResultCollector, mockCore, mockView, mockTestControl, new FakeInfinitestAnnotator()));
 	}
 
 	@Test
@@ -96,26 +96,27 @@ public class WhenTestRunCompleted {
 		verify(mockPresenterListenerBis).testRunCompleted();
 	}
 
-	/*
-	 * @Test FIXME: mocking Succeed/Failed state don't work for me public void
-	 * shouldCallSucceed() {
-	 * presenter.addPresenterListener(mockPresenterListener);
-	 * when(presenter.isSuccess()).thenReturn(true);
-	 * 
-	 * presenter.onComplete();
-	 * 
-	 * verify(mockPresenterListener, never()).testRunFailed();
-	 * verify(mockPresenterListener).testRunSucceed(); }
-	 * 
-	 * @Test public void shouldCallFailed() {
-	 * presenter.addPresenterListener(mockPresenterListener);
-	 * when(presenter.isSuccess()).thenReturn(false);
-	 * 
-	 * presenter.onComplete();
-	 * 
-	 * verify(mockPresenterListener).testRunFailed();
-	 * verify(mockPresenterListener, never()).testRunSucceed(); }
-	 */
+    @Test
+    public void shouldCallSucceed() {
+        presenter.addPresenterListener(mockPresenterListener);
+        when(presenter.isSuccess()).thenReturn(true);
+
+        presenter.onComplete();
+
+        verify(mockPresenterListener, never()).testRunFailed();
+        verify(mockPresenterListener).testRunSucceed();
+    }
+
+    @Test
+    public void shouldCallFailed() {
+        presenter.addPresenterListener(mockPresenterListener);
+        when(presenter.isSuccess()).thenReturn(false);
+
+        presenter.onComplete();
+
+        verify(mockPresenterListener).testRunFailed();
+        verify(mockPresenterListener, never()).testRunSucceed();
+    }
 
 	@Test
 	public void shouldCallWait() {


### PR DESCRIPTION
Fixes a minor TODO by reenabling 2 tests that were expecting to mock object under test.