### PR TITLE
Issue 46: configurable status bar colors

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -94,7 +94,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 		store.setDefault(PARALLEL_CORES, 1);
 		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
 		store.setDefault(FAILING_BACKGROUND_COLOR, ColorSettings.getFailingBackgroundColor());
-		store.setDefault(FAIL_TEXT_COLOR, ColorSettings.getFailTextColor());
+		store.setDefault(FAILING_TEXT_COLOR, ColorSettings.getFailingTextColor());
 	}
 
 	// Only used for testing.
@@ -129,6 +129,6 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 		coreSettings.setConcurrentCoreCount(preferences.getInt(PARALLEL_CORES));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
 		ColorSettings.setFailingBackgroundColor(preferences.getInt(PreferencesConstants.FAILING_BACKGROUND_COLOR));
-		ColorSettings.setFailTextColor(preferences.getInt(PreferencesConstants.FAIL_TEXT_COLOR));
+		ColorSettings.setFailngTextColor(preferences.getInt(PreferencesConstants.FAILING_TEXT_COLOR));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -93,6 +93,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	protected void initializeDefaultPreferences(IPreferenceStore store) {
 		store.setDefault(PARALLEL_CORES, 1);
 		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
+		store.setDefault(FAIL_BACKGROUND_COLOR, ColorSettings.getFailBackgroundColor());
 	}
 
 	// Only used for testing.

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -36,12 +36,13 @@ import static org.infinitest.util.InfinitestUtils.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.jface.preference.*;
 import org.eclipse.ui.plugin.*;
+import org.infinitest.eclipse.prefs.*;
+import org.infinitest.eclipse.trim.*;
 import org.infinitest.eclipse.workspace.*;
 import org.infinitest.util.*;
 import org.osgi.framework.*;
 import org.springframework.context.*;
 import org.springframework.context.annotation.*;
-import org.springframework.context.support.*;
 
 import com.google.common.annotations.*;
 
@@ -113,7 +114,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	@SuppressWarnings("unchecked")
 	public <T> T getBean(Class<T> beanClass) {
 		if (context == null) {
-      context = new AnnotationConfigApplicationContext(InfinitestConfig.class);
+			context = new AnnotationConfigApplicationContext(InfinitestConfig.class);
 
 			restoreSavedPreferences(getPluginPreferences(), getBean(CoreSettings.class));
 			InfinitestUtils.log("Beans loaded: " + asList(context.getBeanDefinitionNames()));
@@ -125,5 +126,6 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	void restoreSavedPreferences(Preferences preferences, CoreSettings coreSettings) {
 		coreSettings.setConcurrentCoreCount(preferences.getInt(PARALLEL_CORES));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
+		ColorSettings.setFailBackgroundColor(preferences.getInt(PreferencesConstants.FAIL_BACKGROUND_COLOR));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -93,7 +93,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	protected void initializeDefaultPreferences(IPreferenceStore store) {
 		store.setDefault(PARALLEL_CORES, 1);
 		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
-		store.setDefault(FAIL_BACKGROUND_COLOR, ColorSettings.getFailBackgroundColor());
+		store.setDefault(FAILING_BACKGROUND_COLOR, ColorSettings.getFailingBackgroundColor());
 		store.setDefault(FAIL_TEXT_COLOR, ColorSettings.getFailTextColor());
 	}
 
@@ -128,7 +128,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	void restoreSavedPreferences(Preferences preferences, CoreSettings coreSettings) {
 		coreSettings.setConcurrentCoreCount(preferences.getInt(PARALLEL_CORES));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
-		ColorSettings.setFailBackgroundColor(preferences.getInt(PreferencesConstants.FAIL_BACKGROUND_COLOR));
+		ColorSettings.setFailingBackgroundColor(preferences.getInt(PreferencesConstants.FAILING_BACKGROUND_COLOR));
 		ColorSettings.setFailTextColor(preferences.getInt(PreferencesConstants.FAIL_TEXT_COLOR));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -94,6 +94,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 		store.setDefault(PARALLEL_CORES, 1);
 		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
 		store.setDefault(FAIL_BACKGROUND_COLOR, ColorSettings.getFailBackgroundColor());
+		store.setDefault(FAIL_TEXT_COLOR, ColorSettings.getFailTextColor());
 	}
 
 	// Only used for testing.
@@ -128,5 +129,6 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 		coreSettings.setConcurrentCoreCount(preferences.getInt(PARALLEL_CORES));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
 		ColorSettings.setFailBackgroundColor(preferences.getInt(PreferencesConstants.FAIL_BACKGROUND_COLOR));
+		ColorSettings.setFailTextColor(preferences.getInt(PreferencesConstants.FAIL_TEXT_COLOR));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -73,6 +73,14 @@ public class PreferenceChangeHandler {
 		if (PreferencesConstants.FAIL_BACKGROUND_COLOR.equals(preference)) {
 			updateFailBackgroundColor((String) newValue);
 		}
+
+		if (PreferencesConstants.FAIL_TEXT_COLOR.equals(preference)) {
+			updateFailTextColor((String) newValue);
+		}
+	}
+
+	private void updateFailTextColor(String newValue) {
+		ColorSettings.setFailTextColor(Integer.valueOf(newValue));
 	}
 
 	private void updateFailBackgroundColor(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -74,13 +74,13 @@ public class PreferenceChangeHandler {
 			updateFailingBackgroundColor((String) newValue);
 		}
 
-		if (PreferencesConstants.FAIL_TEXT_COLOR.equals(preference)) {
-			updateFailTextColor((String) newValue);
+		if (PreferencesConstants.FAILING_TEXT_COLOR.equals(preference)) {
+			updateFailingTextColor((String) newValue);
 		}
 	}
 
-	private void updateFailTextColor(String newValue) {
-		ColorSettings.setFailTextColor(Integer.valueOf(newValue));
+	private void updateFailingTextColor(String newValue) {
+		ColorSettings.setFailngTextColor(Integer.valueOf(newValue));
 	}
 
 	private void updateFailingBackgroundColor(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.preference.*;
 import org.eclipse.jface.util.*;
 import org.infinitest.eclipse.*;
 import org.infinitest.eclipse.markers.*;
+import org.infinitest.eclipse.trim.*;
 import org.infinitest.eclipse.workspace.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
@@ -68,6 +69,14 @@ public class PreferenceChangeHandler {
 		if (PARALLEL_CORES.equals(preference)) {
 			updateConcurrency((String) newValue);
 		}
+
+		if (PreferencesConstants.FAIL_BACKGROUND_COLOR.equals(preference)) {
+			updateFailBackgroundColor((String) newValue);
+		}
+	}
+
+	private void updateFailBackgroundColor(String newValue) {
+		ColorSettings.setFailBackgroundColor(Integer.valueOf(newValue));
 	}
 
 	private void updateConcurrency(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -70,8 +70,8 @@ public class PreferenceChangeHandler {
 			updateConcurrency((String) newValue);
 		}
 
-		if (PreferencesConstants.FAIL_BACKGROUND_COLOR.equals(preference)) {
-			updateFailBackgroundColor((String) newValue);
+		if (PreferencesConstants.FAILING_BACKGROUND_COLOR.equals(preference)) {
+			updateFailingBackgroundColor((String) newValue);
 		}
 
 		if (PreferencesConstants.FAIL_TEXT_COLOR.equals(preference)) {
@@ -83,8 +83,8 @@ public class PreferenceChangeHandler {
 		ColorSettings.setFailTextColor(Integer.valueOf(newValue));
 	}
 
-	private void updateFailBackgroundColor(String newValue) {
-		ColorSettings.setFailBackgroundColor(Integer.valueOf(newValue));
+	private void updateFailingBackgroundColor(String newValue) {
+		ColorSettings.setFailingBackgroundColor(Integer.valueOf(newValue));
 	}
 
 	private void updateConcurrency(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -64,6 +64,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
 		addField(createFailBackgroundColorEditor());
+		addField(createFailTextColorEditor());
 	}
 
 	private BooleanFieldEditor createAutoTestEditor() {
@@ -73,6 +74,10 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	private SwtColorFieldEditor createFailBackgroundColorEditor() {
 		return new SwtColorFieldEditor(PreferencesConstants.FAIL_BACKGROUND_COLOR, "Fail Background Color", getFieldEditorParent());
+	}
+
+	private SwtColorFieldEditor createFailTextColorEditor() {
+		return new SwtColorFieldEditor(PreferencesConstants.FAIL_TEXT_COLOR, "Fail Text Color", getFieldEditorParent());
 	}
 
 	private FieldEditor createSlowTestWarningCutoffEditor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -63,7 +63,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(createAutoTestEditor());
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
-		addField(createFailBackgroundColorEditor());
+		addField(createFailingBackgroundColorEditor());
 		addField(createFailTextColorEditor());
 	}
 
@@ -72,8 +72,8 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		return autoTestEditor;
 	}
 
-	private SwtColorFieldEditor createFailBackgroundColorEditor() {
-		return new SwtColorFieldEditor(PreferencesConstants.FAIL_BACKGROUND_COLOR, "Fail Background Color", getFieldEditorParent());
+	private SwtColorFieldEditor createFailingBackgroundColorEditor() {
+		return new SwtColorFieldEditor(PreferencesConstants.FAILING_BACKGROUND_COLOR, "Fail Background Color", getFieldEditorParent());
 	}
 
 	private SwtColorFieldEditor createFailTextColorEditor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -64,7 +64,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
 		addField(createFailingBackgroundColorEditor());
-		addField(createFailTextColorEditor());
+		addField(createFailingTextColorEditor());
 	}
 
 	private BooleanFieldEditor createAutoTestEditor() {
@@ -76,8 +76,8 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		return new SwtColorFieldEditor(PreferencesConstants.FAILING_BACKGROUND_COLOR, "Fail Background Color", getFieldEditorParent());
 	}
 
-	private SwtColorFieldEditor createFailTextColorEditor() {
-		return new SwtColorFieldEditor(PreferencesConstants.FAIL_TEXT_COLOR, "Fail Text Color", getFieldEditorParent());
+	private SwtColorFieldEditor createFailingTextColorEditor() {
+		return new SwtColorFieldEditor(PreferencesConstants.FAILING_TEXT_COLOR, "Fail Text Color", getFieldEditorParent());
 	}
 
 	private FieldEditor createSlowTestWarningCutoffEditor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -60,10 +60,19 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	protected void createFieldEditors() {
-		BooleanFieldEditor autoTestEditor = new BooleanFieldEditor(AUTO_TEST, "Continuously Test", getFieldEditorParent());
-		addField(autoTestEditor);
+		addField(createAutoTestEditor());
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
+		addField(createFailBackgroundColorEditor());
+	}
+
+	private BooleanFieldEditor createAutoTestEditor() {
+		BooleanFieldEditor autoTestEditor = new BooleanFieldEditor(AUTO_TEST, "Continuously Test", getFieldEditorParent());
+		return autoTestEditor;
+	}
+
+	private SwtColorFieldEditor createFailBackgroundColorEditor() {
+		return new SwtColorFieldEditor(PreferencesConstants.FAIL_BACKGROUND_COLOR, "Fail Background Color", getFieldEditorParent());
 	}
 
 	private FieldEditor createSlowTestWarningCutoffEditor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -43,6 +43,6 @@ public abstract class PreferencesConstants {
 
 	public static final String FAILING_BACKGROUND_COLOR = "org.infinitest.eclipse.color.failing.background";
 
-	public static final String FAIL_TEXT_COLOR = "org.infinitest.eclipse.color.fail.text";
+	public static final String FAILING_TEXT_COLOR = "org.infinitest.eclipse.color.failing.text";
 
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -41,7 +41,7 @@ public abstract class PreferencesConstants {
 
 	public static final String SLOW_TEST_WARNING = "org.infinitest.eclipse.slow-warning";
 
-	public static final String FAIL_BACKGROUND_COLOR = "org.infinitest.eclipse.color.fail.background";
+	public static final String FAILING_BACKGROUND_COLOR = "org.infinitest.eclipse.color.failing.background";
 
 	public static final String FAIL_TEXT_COLOR = "org.infinitest.eclipse.color.fail.text";
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -43,4 +43,6 @@ public abstract class PreferencesConstants {
 
 	public static final String FAIL_BACKGROUND_COLOR = "org.infinitest.eclipse.color.fail.background";
 
+	public static final String FAIL_TEXT_COLOR = "org.infinitest.eclipse.color.fail.text";
+
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -41,4 +41,6 @@ public abstract class PreferencesConstants {
 
 	public static final String SLOW_TEST_WARNING = "org.infinitest.eclipse.slow-warning";
 
+	public static final String FAIL_BACKGROUND_COLOR = "org.infinitest.eclipse.color.fail.background";
+
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/SwtColorFieldEditor.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/SwtColorFieldEditor.java
@@ -4,6 +4,33 @@ import org.eclipse.jface.preference.*;
 import org.eclipse.swt.*;
 import org.eclipse.swt.widgets.*;
 
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 public class SwtColorFieldEditor extends ComboFieldEditor {
 
 	private static final String[][] ENTRY_NAMES_AND_VALUES = {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/SwtColorFieldEditor.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/SwtColorFieldEditor.java
@@ -1,0 +1,33 @@
+package org.infinitest.eclipse.prefs;
+
+import org.eclipse.jface.preference.*;
+import org.eclipse.swt.*;
+import org.eclipse.swt.widgets.*;
+
+public class SwtColorFieldEditor extends ComboFieldEditor {
+
+	private static final String[][] ENTRY_NAMES_AND_VALUES = {
+		{"Black", String.valueOf(SWT.COLOR_BLACK)},
+		{"Blue", String.valueOf(SWT.COLOR_BLUE )},
+		{"Blue (Dark)", String.valueOf(SWT.COLOR_DARK_BLUE)},
+		{"Cyan", String.valueOf(SWT.COLOR_CYAN)},
+		{"Cyan(Dark)", String.valueOf(SWT.COLOR_DARK_CYAN)},
+		{"Green", String.valueOf(SWT.COLOR_GREEN)},
+		{"Green (Dark)", String.valueOf(SWT.COLOR_DARK_GREEN)},
+		{"Gray", String.valueOf(SWT.COLOR_GRAY)},
+		{"Gray (Dark)", String.valueOf(SWT.COLOR_DARK_GRAY)},
+		{"Red", String.valueOf(SWT.COLOR_RED)},
+		{"Red (Dark)", String.valueOf(SWT.COLOR_DARK_RED)},
+		{"Magenta", String.valueOf(SWT.COLOR_MAGENTA)},
+		{"Magenta (Dark)", String.valueOf(SWT.COLOR_DARK_MAGENTA)},
+		{"Yellow", String.valueOf(SWT.COLOR_YELLOW)},
+		{"Yellow (Dark)", String.valueOf(SWT.COLOR_DARK_YELLOW)},
+		{"White", String.valueOf(SWT.COLOR_WHITE)},
+	};
+
+	public SwtColorFieldEditor(String name, String labelText, Composite parent) {
+		super(name, labelText, ENTRY_NAMES_AND_VALUES, parent);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -4,6 +4,15 @@ import org.eclipse.swt.*;
 
 public class ColorSettings {
 	private static int failBackgroundColor = SWT.COLOR_DARK_RED;
+	private static int failTextColor = SWT.COLOR_WHITE;
+
+	public static int getFailTextColor() {
+		return failTextColor;
+	}
+
+	public static void setFailTextColor(int failTextColor) {
+		ColorSettings.failTextColor = failTextColor;
+	}
 
 	public static int getFailBackgroundColor() {
 		return failBackgroundColor;
@@ -12,4 +21,5 @@ public class ColorSettings {
 	public static void setFailBackgroundColor(int failBackgroundColor) {
 		ColorSettings.failBackgroundColor = failBackgroundColor;
 	}
+
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -1,0 +1,15 @@
+package org.infinitest.eclipse.trim;
+
+import org.eclipse.swt.*;
+
+public class ColorSettings {
+	private static int failBackgroundColor = SWT.COLOR_DARK_RED;
+
+	public static int getFailBackgroundColor() {
+		return failBackgroundColor;
+	}
+
+	public static void setFailBackgroundColor(int failBackgroundColor) {
+		ColorSettings.failBackgroundColor = failBackgroundColor;
+	}
+}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -31,14 +31,14 @@ import org.eclipse.swt.*;
  */
 public class ColorSettings {
 	private static int failingBackgroundColor = SWT.COLOR_DARK_RED;
-	private static int failTextColor = SWT.COLOR_WHITE;
+	private static int failingTextColor = SWT.COLOR_WHITE;
 
-	public static int getFailTextColor() {
-		return failTextColor;
+	public static int getFailingTextColor() {
+		return failingTextColor;
 	}
 
-	public static void setFailTextColor(int failTextColor) {
-		ColorSettings.failTextColor = failTextColor;
+	public static void setFailngTextColor(int failTextColor) {
+		ColorSettings.failingTextColor = failTextColor;
 	}
 
 	public static int getFailingBackgroundColor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -2,6 +2,33 @@ package org.infinitest.eclipse.trim;
 
 import org.eclipse.swt.*;
 
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 public class ColorSettings {
 	private static int failBackgroundColor = SWT.COLOR_DARK_RED;
 	private static int failTextColor = SWT.COLOR_WHITE;

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -30,7 +30,7 @@ import org.eclipse.swt.*;
  * SOFTWARE.
  */
 public class ColorSettings {
-	private static int failBackgroundColor = SWT.COLOR_DARK_RED;
+	private static int failingBackgroundColor = SWT.COLOR_DARK_RED;
 	private static int failTextColor = SWT.COLOR_WHITE;
 
 	public static int getFailTextColor() {
@@ -41,12 +41,12 @@ public class ColorSettings {
 		ColorSettings.failTextColor = failTextColor;
 	}
 
-	public static int getFailBackgroundColor() {
-		return failBackgroundColor;
+	public static int getFailingBackgroundColor() {
+		return failingBackgroundColor;
 	}
 
-	public static void setFailBackgroundColor(int failBackgroundColor) {
-		ColorSettings.failBackgroundColor = failBackgroundColor;
+	public static void setFailingBackgroundColor(int failBackgroundColor) {
+		ColorSettings.failingBackgroundColor = failBackgroundColor;
 	}
 
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
@@ -56,8 +56,7 @@ public class VisualStatusPresenter extends TestQueueAdapter implements VisualSta
 	public void coreStatusChanged(CoreStatus oldStatus, CoreStatus newStatus) {
 		switch (newStatus) {
 			case PASSING:
-				status.setBackgroundColor(COLOR_DARK_GREEN);
-				status.setTextColor(COLOR_WHITE);
+				setPassingColors();
 				break;
 			case FAILING:
 				setFailingColors();
@@ -67,8 +66,13 @@ public class VisualStatusPresenter extends TestQueueAdapter implements VisualSta
 		}
 	}
 
+	private void setPassingColors() {
+		status.setBackgroundColor(COLOR_DARK_GREEN);
+		status.setTextColor(COLOR_WHITE);
+	}
+
 	private void setFailingColors() {
-		status.setBackgroundColor(COLOR_DARK_RED);
+		status.setBackgroundColor(ColorSettings.getFailBackgroundColor());
 		status.setTextColor(COLOR_WHITE);
 	}
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
@@ -72,7 +72,7 @@ public class VisualStatusPresenter extends TestQueueAdapter implements VisualSta
 	}
 
 	private void setFailingColors() {
-		status.setBackgroundColor(ColorSettings.getFailBackgroundColor());
+		status.setBackgroundColor(ColorSettings.getFailingBackgroundColor());
 		status.setTextColor(ColorSettings.getFailTextColor());
 	}
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
@@ -73,7 +73,7 @@ public class VisualStatusPresenter extends TestQueueAdapter implements VisualSta
 
 	private void setFailingColors() {
 		status.setBackgroundColor(ColorSettings.getFailBackgroundColor());
-		status.setTextColor(COLOR_WHITE);
+		status.setTextColor(ColorSettings.getFailTextColor());
 	}
 
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/VisualStatusPresenter.java
@@ -73,7 +73,7 @@ public class VisualStatusPresenter extends TestQueueAdapter implements VisualSta
 
 	private void setFailingColors() {
 		status.setBackgroundColor(ColorSettings.getFailingBackgroundColor());
-		status.setTextColor(ColorSettings.getFailTextColor());
+		status.setTextColor(ColorSettings.getFailingTextColor());
 	}
 
 	@Override

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.core.runtime.*;
+import org.infinitest.eclipse.trim.*;
 import org.infinitest.eclipse.workspace.*;
 import org.infinitest.util.*;
 import org.junit.*;
@@ -53,10 +54,12 @@ public class WhenPluginIsLoaded {
 	public void shouldRestoreSavedPreferences() {
 		when(preferences.getInt(PARALLEL_CORES)).thenReturn(4);
 		when(preferences.getLong(SLOW_TEST_WARNING)).thenReturn(1000L);
+		when(preferences.getInt(FAIL_BACKGROUND_COLOR)).thenReturn(1);
 
 		plugin.restoreSavedPreferences(preferences, coreSettings);
 
 		verify(coreSettings).setConcurrentCoreCount(4);
 		assertEquals(1000L, InfinitestGlobalSettings.getSlowTestTimeLimit());
+		assertEquals(1, ColorSettings.getFailBackgroundColor());
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
@@ -55,13 +55,13 @@ public class WhenPluginIsLoaded {
 		when(preferences.getInt(PARALLEL_CORES)).thenReturn(4);
 		when(preferences.getLong(SLOW_TEST_WARNING)).thenReturn(1000L);
 		when(preferences.getInt(FAILING_BACKGROUND_COLOR)).thenReturn(1);
-		when(preferences.getInt(FAIL_TEXT_COLOR)).thenReturn(2);
+		when(preferences.getInt(FAILING_TEXT_COLOR)).thenReturn(2);
 
 		plugin.restoreSavedPreferences(preferences, coreSettings);
 
 		verify(coreSettings).setConcurrentCoreCount(4);
 		assertEquals(1000L, InfinitestGlobalSettings.getSlowTestTimeLimit());
 		assertEquals(1, ColorSettings.getFailingBackgroundColor());
-		assertEquals(2, ColorSettings.getFailTextColor());
+		assertEquals(2, ColorSettings.getFailingTextColor());
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
@@ -55,11 +55,13 @@ public class WhenPluginIsLoaded {
 		when(preferences.getInt(PARALLEL_CORES)).thenReturn(4);
 		when(preferences.getLong(SLOW_TEST_WARNING)).thenReturn(1000L);
 		when(preferences.getInt(FAIL_BACKGROUND_COLOR)).thenReturn(1);
+		when(preferences.getInt(FAIL_TEXT_COLOR)).thenReturn(2);
 
 		plugin.restoreSavedPreferences(preferences, coreSettings);
 
 		verify(coreSettings).setConcurrentCoreCount(4);
 		assertEquals(1000L, InfinitestGlobalSettings.getSlowTestTimeLimit());
 		assertEquals(1, ColorSettings.getFailBackgroundColor());
+		assertEquals(2, ColorSettings.getFailTextColor());
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenPluginIsLoaded.java
@@ -54,14 +54,14 @@ public class WhenPluginIsLoaded {
 	public void shouldRestoreSavedPreferences() {
 		when(preferences.getInt(PARALLEL_CORES)).thenReturn(4);
 		when(preferences.getLong(SLOW_TEST_WARNING)).thenReturn(1000L);
-		when(preferences.getInt(FAIL_BACKGROUND_COLOR)).thenReturn(1);
+		when(preferences.getInt(FAILING_BACKGROUND_COLOR)).thenReturn(1);
 		when(preferences.getInt(FAIL_TEXT_COLOR)).thenReturn(2);
 
 		plugin.restoreSavedPreferences(preferences, coreSettings);
 
 		verify(coreSettings).setConcurrentCoreCount(4);
 		assertEquals(1000L, InfinitestGlobalSettings.getSlowTestTimeLimit());
-		assertEquals(1, ColorSettings.getFailBackgroundColor());
+		assertEquals(1, ColorSettings.getFailingBackgroundColor());
 		assertEquals(2, ColorSettings.getFailTextColor());
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -103,14 +103,14 @@ public class WhenPreferencesAreChanged {
 	}
 
 	@Test
-	public void shouldAdjustFailTextColor() {
-		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAIL_TEXT_COLOR);
+	public void shouldAdjustFailingTextColor() {
+		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAILING_TEXT_COLOR);
 		int white = SWT.COLOR_WHITE;
 		int yellow = SWT.COLOR_YELLOW;
 
 		changeProperty(SwtColorFieldEditor.VALUE, String.valueOf(white), String.valueOf(yellow));
 
-		assertEquals(yellow, ColorSettings.getFailTextColor());
+		assertEquals(yellow, ColorSettings.getFailingTextColor());
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -97,9 +97,20 @@ public class WhenPreferencesAreChanged {
 		int red = SWT.COLOR_DARK_RED;
 		int blue = SWT.COLOR_BLUE;
 
-		changeProperty(SwtColorFieldEditor.VALUE, red, String.valueOf(blue));
+		changeProperty(SwtColorFieldEditor.VALUE, String.valueOf(red), String.valueOf(blue));
 
 		assertEquals(blue, ColorSettings.getFailBackgroundColor());
+	}
+
+	@Test
+	public void shouldAdjustFailTextColor() {
+		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAIL_TEXT_COLOR);
+		int white = SWT.COLOR_WHITE;
+		int yellow = SWT.COLOR_YELLOW;
+
+		changeProperty(SwtColorFieldEditor.VALUE, String.valueOf(white), String.valueOf(yellow));
+
+		assertEquals(yellow, ColorSettings.getFailTextColor());
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -35,8 +35,10 @@ import static org.mockito.Mockito.*;
 
 import org.eclipse.jface.preference.*;
 import org.eclipse.jface.util.*;
+import org.eclipse.swt.*;
 import org.infinitest.eclipse.*;
 import org.infinitest.eclipse.markers.*;
+import org.infinitest.eclipse.trim.*;
 import org.infinitest.eclipse.workspace.*;
 import org.junit.*;
 
@@ -87,6 +89,17 @@ public class WhenPreferencesAreChanged {
 		when(eventSource.getPreferenceName()).thenReturn(SLOW_TEST_WARNING);
 		changeProperty(VALUE, "500", "100");
 		assertEquals(100, getSlowTestTimeLimit());
+	}
+
+	@Test
+	public void shouldAdjustFailBackgroundColor() {
+		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAIL_BACKGROUND_COLOR);
+		int red = SWT.COLOR_DARK_RED;
+		int blue = SWT.COLOR_BLUE;
+
+		changeProperty(SwtColorFieldEditor.VALUE, red, String.valueOf(blue));
+
+		assertEquals(blue, ColorSettings.getFailBackgroundColor());
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -92,14 +92,14 @@ public class WhenPreferencesAreChanged {
 	}
 
 	@Test
-	public void shouldAdjustFailBackgroundColor() {
-		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAIL_BACKGROUND_COLOR);
+	public void shouldAdjustFailingBackgroundColor() {
+		when(eventSource.getPreferenceName()).thenReturn(PreferencesConstants.FAILING_BACKGROUND_COLOR);
 		int red = SWT.COLOR_DARK_RED;
 		int blue = SWT.COLOR_BLUE;
 
 		changeProperty(SwtColorFieldEditor.VALUE, String.valueOf(red), String.valueOf(blue));
 
-		assertEquals(blue, ColorSettings.getFailBackgroundColor());
+		assertEquals(blue, ColorSettings.getFailingBackgroundColor());
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -74,7 +74,7 @@ public class WhenShowingStatusInTheStatusBar {
 	public void shouldImmediatelySetStatusToFailingWhenATestFails() {
 		presenter.testCaseComplete(new TestCaseEvent("", null, new TestResults(methodFailed("", "", new AssertionError()))));
 
-		verify(statusBar).setBackgroundColor(ColorSettings.getFailBackgroundColor());
+		verify(statusBar).setBackgroundColor(ColorSettings.getFailingBackgroundColor());
 		verify(statusBar).setTextColor(ColorSettings.getFailTextColor());
 	}
 
@@ -111,8 +111,8 @@ public class WhenShowingStatusInTheStatusBar {
 	}
 
 	@Test
-	public void shouldChangeToFailBackgroundColorWhenTestsFail() {
-		ColorSettings.setFailBackgroundColor(COLOR_DARK_RED);
+	public void shouldChangeToFailingBackgroundColorWhenTestsFail() {
+		ColorSettings.setFailingBackgroundColor(COLOR_DARK_RED);
 		ColorSettings.setFailTextColor(COLOR_YELLOW);
 
 		presenter.coreStatusChanged(PASSING, FAILING);

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -75,7 +75,7 @@ public class WhenShowingStatusInTheStatusBar {
 		presenter.testCaseComplete(new TestCaseEvent("", null, new TestResults(methodFailed("", "", new AssertionError()))));
 
 		verify(statusBar).setBackgroundColor(ColorSettings.getFailBackgroundColor());
-		verify(statusBar).setTextColor(COLOR_WHITE);
+		verify(statusBar).setTextColor(ColorSettings.getFailTextColor());
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
+import org.eclipse.swt.*;
 import org.infinitest.*;
 import org.infinitest.eclipse.status.*;
 import org.infinitest.testrunner.*;
@@ -74,7 +75,7 @@ public class WhenShowingStatusInTheStatusBar {
 	public void shouldImmediatelySetStatusToFailingWhenATestFails() {
 		presenter.testCaseComplete(new TestCaseEvent("", null, new TestResults(methodFailed("", "", new AssertionError()))));
 
-		verify(statusBar).setBackgroundColor(COLOR_DARK_RED);
+		verify(statusBar).setBackgroundColor(ColorSettings.getFailBackgroundColor());
 		verify(statusBar).setTextColor(COLOR_WHITE);
 	}
 
@@ -111,10 +112,12 @@ public class WhenShowingStatusInTheStatusBar {
 	}
 
 	@Test
-	public void shouldChangeToRedWhenTestsFail() {
+	public void shouldChangeToFailBackgroundColorWhenTestsFail() {
+		ColorSettings.setFailBackgroundColor(SWT.COLOR_DARK_RED);
+
 		presenter.coreStatusChanged(PASSING, FAILING);
 
-		verify(statusBar).setBackgroundColor(COLOR_DARK_RED);
+		verify(statusBar).setBackgroundColor(ColorSettings.getFailBackgroundColor());
 		verify(statusBar).setTextColor(COLOR_WHITE);
 	}
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
-import org.eclipse.swt.*;
 import org.infinitest.*;
 import org.infinitest.eclipse.status.*;
 import org.infinitest.testrunner.*;
@@ -113,12 +112,13 @@ public class WhenShowingStatusInTheStatusBar {
 
 	@Test
 	public void shouldChangeToFailBackgroundColorWhenTestsFail() {
-		ColorSettings.setFailBackgroundColor(SWT.COLOR_DARK_RED);
+		ColorSettings.setFailBackgroundColor(COLOR_DARK_RED);
+		ColorSettings.setFailTextColor(COLOR_YELLOW);
 
 		presenter.coreStatusChanged(PASSING, FAILING);
 
-		verify(statusBar).setBackgroundColor(ColorSettings.getFailBackgroundColor());
-		verify(statusBar).setTextColor(COLOR_WHITE);
+		verify(statusBar).setBackgroundColor(COLOR_DARK_RED);
+		verify(statusBar).setTextColor(COLOR_YELLOW);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -75,7 +75,7 @@ public class WhenShowingStatusInTheStatusBar {
 		presenter.testCaseComplete(new TestCaseEvent("", null, new TestResults(methodFailed("", "", new AssertionError()))));
 
 		verify(statusBar).setBackgroundColor(ColorSettings.getFailingBackgroundColor());
-		verify(statusBar).setTextColor(ColorSettings.getFailTextColor());
+		verify(statusBar).setTextColor(ColorSettings.getFailingTextColor());
 	}
 
 	@Test
@@ -113,7 +113,7 @@ public class WhenShowingStatusInTheStatusBar {
 	@Test
 	public void shouldChangeToFailingBackgroundColorWhenTestsFail() {
 		ColorSettings.setFailingBackgroundColor(COLOR_DARK_RED);
-		ColorSettings.setFailTextColor(COLOR_YELLOW);
+		ColorSettings.setFailngTextColor(COLOR_YELLOW);
 
 		presenter.coreStatusChanged(PASSING, FAILING);
 


### PR DESCRIPTION
This is a try at implementing the improvement requested in issue #46.
I have implemented the configuration of the status bar's background color in case the tests fail.
I would like some feedback on this implementation and if it is acceptable for you I would implement the configuration for the remaining three background colors and the four text colors accordingly.
