### PR TITLE
Issue #174: Eclipse problem markers now remove new lines from error messages

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerInfo.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerInfo.java
@@ -116,6 +116,9 @@ public class ProblemMarkerInfo extends AbstractMarkerInfo {
 		if (isBlank(message) || isStringifiedNull(message)) {
 			return "";
 		}
+		
+		message = message.replaceAll("\\r|\\n", " ");
+		
 		return " (" + message + ")";
 	}
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
@@ -35,6 +35,8 @@ import static org.infinitest.testrunner.TestEvent.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import org.eclipse.core.resources.IMarker;
+import org.infinitest.eclipse.workspace.FakeResourceFinder;
 import org.infinitest.testrunner.*;
 import org.junit.*;
 
@@ -87,6 +89,24 @@ public class WhenCreatingMarkers {
 
 		MarkerInfo marker = getOnlyElement(registry.getMarkers());
 		assertEquals(error.getClass().getSimpleName() + " in " + "TestName.methodName", getAttribute(marker, MESSAGE));
+	}
+
+	@Test
+	public void shouldRemoveLineBreaksFromErrorMessages() {
+		Throwable throwable = new Exception("message with\nline break");
+		ProblemMarkerInfo info = new ProblemMarkerInfo(methodFailed("testName", "methodName", throwable), new FakeResourceFinder());
+		
+		String message = (String) info.attributes().get(IMarker.MESSAGE);
+		assertThat(message, containsString("message with line break"));
+	}
+
+	@Test
+	public void shouldRemoveCarraigeReturnsFromErrorMessages() {
+		Throwable throwable = new Exception("message with\rline break");
+		ProblemMarkerInfo info = new ProblemMarkerInfo(methodFailed("testName", "methodName", throwable), new FakeResourceFinder());
+		
+		String message = (String) info.attributes().get(IMarker.MESSAGE);
+		assertThat(message, containsString("message with line break"));
 	}
 
 	private Object getAttribute(MarkerInfo marker, String message) {


### PR DESCRIPTION
Fix for [Issue #174](https://github.com/infinitest/infinitest/issues/174).