### PR TITLE
Fix Resource Filtering

### DIFF
--- a/infinitest-eclipse/src/main/assembly/assembly-feature.xml
+++ b/infinitest-eclipse/src/main/assembly/assembly-feature.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <assembly xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/assembly-1.1.0-SNAPSHOT.xsd">
-    <id>feature</id>
-    <baseDirectory></baseDirectory>
-    <formats>
-        <format>jar</format>
-    </formats>
-    <files>
-        <file>
-            <source>feature.xml</source>
-            <filtered>true</filtered>
-        </file>
-    </files>
+	<id>feature</id>
+	<baseDirectory></baseDirectory>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<files>
+		<file>
+			<source>feature.xml</source>
+			<filtered>true</filtered>
+		</file>
+	</files>
 </assembly>

--- a/infinitest-eclipse/src/main/assembly/assembly-feature.xml
+++ b/infinitest-eclipse/src/main/assembly/assembly-feature.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
 <assembly xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/assembly-1.1.0-SNAPSHOT.xsd">
-	<id>feature</id>
-	<baseDirectory></baseDirectory>
-	<formats>
-		<format>jar</format>
-	</formats>
-	<fileSets>
-		<fileSet>
-			<filtered>true</filtered>
-			<includes>
-				<include>feature.xml</include>
-			</includes>
-		</fileSet>
-	</fileSets>
+    <id>feature</id>
+    <baseDirectory></baseDirectory>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <files>
+        <file>
+            <source>feature.xml</source>
+            <filtered>true</filtered>
+        </file>
+    </files>
 </assembly>

--- a/infinitest-eclipse/src/main/assembly/assembly-plugin.xml
+++ b/infinitest-eclipse/src/main/assembly/assembly-plugin.xml
@@ -7,7 +7,6 @@
 	</formats>
 	<fileSets>
 		<fileSet>
-			<filtered>false</filtered>
 			<directory>target/classes</directory>
 			<outputDirectory></outputDirectory>
 			<includes>
@@ -15,7 +14,6 @@
 			</includes>
 		</fileSet>
 		<fileSet>
-			<filtered>true</filtered>
 			<directory>${basedir}</directory>
 			<outputDirectory></outputDirectory>
 			<includes>


### PR DESCRIPTION
Fixed resource filtering during assembly of the feature JAR by using ``<files>`` and ``<file>`` as suggested by the [assembly plug-in documentation](https://maven.apache.org/plugins/maven-assembly-plugin/examples/single/filtering-some-distribution-files.html).

See also infinitest/infinitest#180.