### PR TITLE
Issue #187: No tests executed if path contains space

### DIFF
--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
@@ -100,12 +100,16 @@ public class JavaAssistClassParser {
 			if (unparsableClass(ctClass)) {
 				clazz = new UnparsableClass(className);
 			} else {
-				JavaAssistClass javaAssistClass = new JavaAssistClass(ctClass);
-				URL url = getClassPool().find(className);
-				if ((url != null) && url.getProtocol().equals("file")) {
-					javaAssistClass.setClassFile(new File(url.getFile()));
+				try {
+					JavaAssistClass javaAssistClass = new JavaAssistClass(ctClass);
+					URL url = getClassPool().find(className);
+					if ((url != null) && url.getProtocol().equals("file")) {
+						javaAssistClass.setClassFile(new File(url.toURI()));
+					}
+					clazz = javaAssistClass;
+				} catch (URISyntaxException e) {
+					throw new RuntimeException(e);
 				}
-				clazz = javaAssistClass;
 			}
 
 			CLASSES_BY_NAME.put(className, clazz);


### PR DESCRIPTION
The issue is caused by ClassFileTestDetector filtering out any test files containing spaces. In the test file names spaces are escaped with '%20' but in the list of the project's class directories spaces are unescaped. Because of that inCurrentProject() always returns false.
The issue is fixed by creating the test class File objects from an URI. That will decode any URL encoded spaces in the file name. 