### PR TITLE
Enabling whitelist-filtering

### DIFF
--- a/infinitest-lib/src/main/java/org/infinitest/filter/RegexFileFilter.java
+++ b/infinitest-lib/src/main/java/org/infinitest/filter/RegexFileFilter.java
@@ -32,13 +32,13 @@ import static org.infinitest.util.InfinitestUtils.*;
 
 import java.io.*;
 import java.util.*;
-import java.util.Optional;
 import java.util.regex.*;
 
 import org.infinitest.parser.*;
 
 import com.google.common.base.*;
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.io.*;
 
 public class RegexFileFilter implements TestFilter {
@@ -88,7 +88,7 @@ public class RegexFileFilter implements TestFilter {
 	private Optional<FilterEntry> readyFilterEntry(String line) {
 
 		if (!isValidFilterLine(line)) {
-			return Optional.empty();
+			return Optional.absent();
 		}
 
 		boolean including = line.startsWith("include=");

--- a/infinitest-lib/src/main/java/org/infinitest/filter/RegexFileFilter.java
+++ b/infinitest-lib/src/main/java/org/infinitest/filter/RegexFileFilter.java
@@ -27,27 +27,28 @@
  */
 package org.infinitest.filter;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.logging.Level.*;
-import static org.apache.commons.lang.StringUtils.*;
 import static org.infinitest.util.InfinitestUtils.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.Optional;
 import java.util.regex.*;
 
 import org.infinitest.parser.*;
 
 import com.google.common.base.*;
+import com.google.common.base.Objects;
 import com.google.common.io.*;
 
 public class RegexFileFilter implements TestFilter {
-	private final File file;
-	private final List<Pattern> filters = newArrayList();
-	private boolean isInverted = false;
+
+	private final File filterFile;
+	private final Set<FilterEntry> includeFilterEntries = new LinkedHashSet<FilterEntry>();
+	private final Set<FilterEntry> excludeFilterEntries = new LinkedHashSet<FilterEntry>();
 
 	public RegexFileFilter(File file) {
-		this.file = file;
+		this.filterFile = file;
 		if (!file.exists()) {
 			log(INFO, "Filter file " + file + " does not exist.");
 		}
@@ -55,48 +56,116 @@ public class RegexFileFilter implements TestFilter {
 	}
 
 	@Override
-	public boolean match(JavaClass javaClass) {
-		String className = javaClass.getName();
-		for (Pattern pattern : filters) {
-			if (pattern.matcher(className).lookingAt()) {
-				return !isInverted;
+	public void updateFilterList() {
+
+		includeFilterEntries.clear();
+		excludeFilterEntries.clear();
+
+		try {
+			List<String> lines = Files.readLines(filterFile, Charsets.UTF_8);
+			for (String line : lines) {
+
+				Optional<FilterEntry> filterEntry = readyFilterEntry(line);
+				if (filterEntry.isPresent()) {
+					addFilterEntry(filterEntry.get());
+				}
+
 			}
+
+		} catch (IOException e) {
+			log(WARNING, "failed to read filter file: " + filterFile);
 		}
-		return isInverted;
+	}
+
+	private void addFilterEntry(FilterEntry filterEntry) {
+		if (filterEntry.including) {
+			includeFilterEntries.add(filterEntry);
+		} else {
+			excludeFilterEntries.add(filterEntry);
+		}
+	}
+
+	private Optional<FilterEntry> readyFilterEntry(String line) {
+
+		if (!isValidFilterLine(line)) {
+			return Optional.empty();
+		}
+
+		boolean including = line.startsWith("include=");
+		String expression = line;
+		if (line.contains("=")) {
+			expression = line.substring(line.indexOf("=") + 1);
+		}
+
+		return Optional.of(new FilterEntry(including, expression));
+	}
+
+	private boolean isValidFilterLine(String line) {
+		return !Strings.isNullOrEmpty(line) && !line.startsWith("!") && !line.startsWith("#");
 	}
 
 	@Override
-	public void updateFilterList() {
-		filters.clear();
-		this.isInverted = false;
+	public boolean match(JavaClass javaClass) {
 
-		if (file.exists()) {
-			readFilterFile();
+		if (!includeFilterEntries.isEmpty() && !matchesFilters(javaClass, includeFilterEntries)) {
+			return true;
 		}
+
+		return matchesFilters(javaClass, excludeFilterEntries);
 	}
 
-	private void readFilterFile() {
-		try {
-
-			for (String line : Files.readLines(file, Charsets.UTF_8)) {
-
-				if (filters.isEmpty() && isWhitelistFilterOption(line)) {
-					this.isInverted = true;
-				} else if (isValidFilter(line)) {
-					filters.add(Pattern.compile(line));
-				}
+	private boolean matchesFilters(JavaClass javaClass, Set<FilterEntry> entries) {
+		for (FilterEntry entry : entries) {
+			if (entry.matches(javaClass.getName())) {
+				return true;
 			}
-		} catch (IOException e) {
-			throw new RuntimeException("Something horrible happened to the filter file", e);
 		}
+		return false;
 	}
 
-	private boolean isWhitelistFilterOption(String line) {
-		return !isBlank(line) && line.startsWith("!whitelist");
-	}
+	private static class FilterEntry {
 
-	private boolean isValidFilter(String line) {
-		return !isBlank(line) && !line.startsWith("!") && !line.startsWith("#");
+		final boolean including;
+		final String expression;
+		final Pattern pattern;
+
+		FilterEntry(boolean including, String expression) {
+			this.including = including;
+			this.expression = expression;
+			this.pattern = Pattern.compile(expression);
+		}
+
+		public boolean matches(String name) {
+			Matcher matcher = pattern.matcher(name);
+			return matcher.matches() || matcher.lookingAt();
+		}
+
+		@Override
+		public String toString() {
+			return expression;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(including, expression);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+
+			FilterEntry other = (FilterEntry) obj;
+			return Objects.equal(including, other.including) && Objects.equal(expression, other.expression);
+		}
+
 	}
 
 }

--- a/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
+++ b/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
@@ -57,15 +57,6 @@ public class TestFilterList {
 	}
 
 	@Test
-	public void shouldNotInvertWhenKeywordIsPlacedAfterFirstFilter() throws Exception {
-
-		TestFilter filter = new RegexFileFilter(file("MyOtherClassName\n!whitelist\nMyClassName\n"));
-
-		assertTrue(filter.match(javaClass("MyClassName")));
-		assertTrue(filter.match(javaClass("MyOtherClassName")));
-	}
-
-	@Test
 	public void testJMockClasses() {
 		TestFilter filter = new RegexFileFilter(file("org.jmock.test.acceptance.junit4.testdata.JUnit4TestWithNonPublicBeforeMethod"));
 

--- a/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
+++ b/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
@@ -57,15 +57,6 @@ public class TestFilterList {
 	}
 
 	@Test
-	public void shouldInvertWhenKeywordIsPlacedBeforeFirstFilter() throws Exception {
-
-		TestFilter filter = new RegexFileFilter(file("\n\n!whitelist\nMyClassName\n"));
-
-		assertFalse(filter.match(javaClass("MyClassName")));
-		assertTrue(filter.match(javaClass("MyOtherClassName")));
-	}
-
-	@Test
 	public void shouldNotInvertWhenKeywordIsPlacedAfterFirstFilter() throws Exception {
 
 		TestFilter filter = new RegexFileFilter(file("MyOtherClassName\n!whitelist\nMyClassName\n"));

--- a/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
+++ b/infinitest-lib/src/test/java/org/infinitest/TestFilterList.java
@@ -38,80 +38,97 @@ import org.junit.*;
 import org.junit.rules.*;
 
 public class TestFilterList {
-  private final static String TEST_FILTER_LIST_REGEX = "org\\.infinitest\\.TestFilterList";
+	private final static String TEST_FILTER_LIST_REGEX = "org\\.infinitest\\.TestFilterList";
 
-  @ClassRule
-  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @Test
-  public void testFilterList() throws IOException {
-    TestFilter filter = new RegexFileFilter(file(TEST_FILTER_LIST_REGEX + "\n!foo.bar\n#foo.bar"));
+	@Test
+	public void testFilterList() throws IOException {
+		TestFilter filter = new RegexFileFilter(file(TEST_FILTER_LIST_REGEX + "\n!foo.bar\n#foo.bar"));
 
-    assertTrue(filter.match(javaClass(TestFilterList.class)));
-  }
+		assertTrue(filter.match(javaClass(TestFilterList.class)));
+	}
 
-  @Test
-  public void shouldIgnoreAllBlankLines() {
-    TestFilter filter = new RegexFileFilter(file("\n\n"));
+	@Test
+	public void shouldIgnoreAllBlankLines() {
+		TestFilter filter = new RegexFileFilter(file("\n\n"));
 
-    assertFalse(filter.match(javaClass("MyClassName")));
-  }
+		assertFalse(filter.match(javaClass("MyClassName")));
+	}
 
-  @Test
-  public void testJMockClasses() {
-    TestFilter filter = new RegexFileFilter(file("org.jmock.test.acceptance.junit4.testdata.JUnit4TestWithNonPublicBeforeMethod"));
+	@Test
+	public void shouldInvertWhenKeywordIsPlacedBeforeFirstFilter() throws Exception {
 
-    assertTrue(filter.match(javaClass("org.jmock.test.acceptance.junit4.testdata.JUnit4TestWithNonPublicBeforeMethod")));
-  }
+		TestFilter filter = new RegexFileFilter(file("\n\n!whitelist\nMyClassName\n"));
 
-  @Test
-  public void testFiltering() {
-    TestFilter filter = new RegexFileFilter(file("org\\.infinitest\\..*"));
+		assertFalse(filter.match(javaClass("MyClassName")));
+		assertTrue(filter.match(javaClass("MyOtherClassName")));
+	}
 
-    assertFalse(filter.match(javaClass(com.fakeco.fakeproduct.TestFakeProduct.class)));
-    assertFalse(filter.match(javaClass(com.fakeco.fakeproduct.FakeProduct.class)));
-    assertTrue(filter.match(javaClass(org.infinitest.changedetect.WhenLookingForClassFiles.class)));
-  }
+	@Test
+	public void shouldNotInvertWhenKeywordIsPlacedAfterFirstFilter() throws Exception {
 
-  @Test
-  public void testSingleTest() {
-    TestFilter filter = new RegexFileFilter(file(TEST_FILTER_LIST_REGEX));
+		TestFilter filter = new RegexFileFilter(file("MyOtherClassName\n!whitelist\nMyClassName\n"));
 
-    assertFalse(filter.match(javaClass(RegexFileFilter.class)));
-    assertTrue("Single test should match regex", filter.match(javaClass(TestFilterList.class)));
-  }
+		assertTrue(filter.match(javaClass("MyClassName")));
+		assertTrue(filter.match(javaClass("MyOtherClassName")));
+	}
 
-  @Test
-  public void testLeadingWildcard() {
-    TestFilter filter = new RegexFileFilter(file(".*TestFilterList"));
+	@Test
+	public void testJMockClasses() {
+		TestFilter filter = new RegexFileFilter(file("org.jmock.test.acceptance.junit4.testdata.JUnit4TestWithNonPublicBeforeMethod"));
 
-    assertTrue(filter.match(javaClass(TestFilterList.class)));
-  }
+		assertTrue(filter.match(javaClass("org.jmock.test.acceptance.junit4.testdata.JUnit4TestWithNonPublicBeforeMethod")));
+	}
 
-  @Test
-  public void testTrailingWildcard() {
-    TestFilter filter = new RegexFileFilter(file("org\\..*"));
+	@Test
+	public void testFiltering() {
+		TestFilter filter = new RegexFileFilter(file("org\\.infinitest\\..*"));
 
-    assertTrue(filter.match(javaClass(TestFilterList.class)));
-  }
+		assertFalse(filter.match(javaClass(com.fakeco.fakeproduct.TestFakeProduct.class)));
+		assertFalse(filter.match(javaClass(com.fakeco.fakeproduct.FakeProduct.class)));
+		assertTrue(filter.match(javaClass(org.infinitest.changedetect.WhenLookingForClassFiles.class)));
+	}
 
-  static File file(String content) {
-    try {
-      File file = temporaryFolder.newFile();
-      new PrintWriter(file).append(content).close();
-      return file;
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+	@Test
+	public void testSingleTest() {
+		TestFilter filter = new RegexFileFilter(file(TEST_FILTER_LIST_REGEX));
 
-  static JavaClass javaClass(Class<?> clazz) {
-    return javaClass(clazz.getName());
-  }
+		assertFalse(filter.match(javaClass(RegexFileFilter.class)));
+		assertTrue("Single test should match regex", filter.match(javaClass(TestFilterList.class)));
+	}
 
-  static JavaClass javaClass(String name) {
-    JavaClass javaClass = mock(JavaClass.class);
-    when(javaClass.getName()).thenReturn(name);
-    return javaClass;
-  }
+	@Test
+	public void testLeadingWildcard() {
+		TestFilter filter = new RegexFileFilter(file(".*TestFilterList"));
+
+		assertTrue(filter.match(javaClass(TestFilterList.class)));
+	}
+
+	@Test
+	public void testTrailingWildcard() {
+		TestFilter filter = new RegexFileFilter(file("org\\..*"));
+
+		assertTrue(filter.match(javaClass(TestFilterList.class)));
+	}
+
+	static File file(String content) {
+		try {
+			File file = temporaryFolder.newFile();
+			new PrintWriter(file).append(content).close();
+			return file;
+		} catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	static JavaClass javaClass(Class<?> clazz) {
+		return javaClass(clazz.getName());
+	}
+
+	static JavaClass javaClass(String name) {
+		JavaClass javaClass = mock(JavaClass.class);
+		when(javaClass.getName()).thenReturn(name);
+		return javaClass;
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
@@ -38,6 +38,8 @@ import org.junit.*;
 import org.junit.rules.*;
 import org.testng.reporters.*;
 
+import com.google.common.base.*;
+
 public class RegexFileFilterTest {
 
 	@Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -146,7 +148,7 @@ public class RegexFileFilterTest {
 
 	private File createFilterFile(String... lines) throws Exception {
 		File file = temporaryFolder.newFile();
-		String content = String.join("\n", lines);
+		String content = Joiner.on("\n").join(lines);
 		Files.writeFile(content, file);
 		return file;
 	}

--- a/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
@@ -1,0 +1,160 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.filter;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.*;
+
+import org.infinitest.parser.*;
+import org.junit.*;
+import org.junit.rules.*;
+import org.testng.reporters.*;
+
+public class RegexFileFilterTest {
+
+	@Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testFilterContentIsEmpty() throws Exception {
+
+		File filterFile = createFilterFile();
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(false));
+	}
+
+	@Test
+	public void testFilterContentContainsSimpleEntry() throws Exception {
+
+		File filterFile = createFilterFile("SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(true));
+	}
+
+	@Test
+	public void testFilterContentContainsBlankLines() throws Exception {
+
+		File filterFile = createFilterFile("", "SomeTest", "");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(true));
+	}
+
+	@Test
+	public void testFilterContentContainsCommentedLines() throws Exception {
+
+		File filterFile = createFilterFile("!SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(false));
+	}
+
+	@Test
+	public void testFilterContentContainsCommentedLines2() throws Exception {
+
+		File filterFile = createFilterFile("#SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(false));
+	}
+
+	@Test
+	public void testFilterContentContainsSimpleEntryButDoesNotMatch() throws Exception {
+
+		File filterFile = createFilterFile("SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("OtherTest")), is(false));
+	}
+
+	@Test
+	public void testFilterContentContainsSimpleExcludesEntry() throws Exception {
+
+		File filterFile = createFilterFile("excludes=SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(true));
+	}
+
+	@Test
+	public void testFilterContentContainsSimpleIncludesEntry() throws Exception {
+
+		File filterFile = createFilterFile("include=SomeTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(false));
+		assertThat(filter.match(mockClass("OtherTest")), is(true));
+	}
+
+	@Test
+	public void testFilterContentContainsIncludesExcludesEntries() throws Exception {
+
+		File filterFile = createFilterFile("include=SomeTest", "exclude=.*Test");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("SomeTest")), is(true));
+		assertThat(filter.match(mockClass("OtherTest")), is(true));
+		assertThat(filter.match(mockClass("FooTest")), is(true));
+
+	}
+
+	@Test
+	public void testFilterContentContainsComplexEntries() throws Exception {
+
+		File filterFile = createFilterFile("include=com\\.mycompany\\.mypackage1\\.*", "include=com\\.mycompany\\.mypackage2\\.*", "exclude=.*IT", "exclude=.*SlowTest");
+		RegexFileFilter filter = new RegexFileFilter(filterFile);
+
+		assertThat(filter.match(mockClass("com.mycompany.mypackage1.SomeTest")), is(false));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage2.SomeTest")), is(false));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage3.SomeTest")), is(true));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage1.SomeIT")), is(true));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage2.OtherIT")), is(true));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage1.SlowTest")), is(true));
+		assertThat(filter.match(mockClass("com.mycompany.mypackage2.OtherTest")), is(false));
+		assertThat(filter.match(mockClass("OtherTest")), is(true));
+		assertThat(filter.match(mockClass("SomeTest")), is(true));
+	}
+
+	private File createFilterFile(String... lines) throws Exception {
+		File file = temporaryFolder.newFile();
+		String content = String.join("\n", lines);
+		Files.writeFile(content, file);
+		return file;
+	}
+
+	private JavaClass mockClass(String name) {
+		JavaClass javaClass = mock(JavaClass.class);
+		when(javaClass.getName()).thenReturn(name);
+		return javaClass;
+	}
+
+}

--- a/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/filter/RegexFileFilterTest.java
@@ -101,7 +101,7 @@ public class RegexFileFilterTest {
 	@Test
 	public void testFilterContentContainsSimpleExcludesEntry() throws Exception {
 
-		File filterFile = createFilterFile("excludes=SomeTest");
+		File filterFile = createFilterFile("exclude=SomeTest");
 		RegexFileFilter filter = new RegexFileFilter(filterFile);
 
 		assertThat(filter.match(mockClass("SomeTest")), is(true));


### PR DESCRIPTION
A line with the content “!whitelist” can be added to the filter list in order to invert the filters. Only tests matching any of the given filter patterns will be run.