### PR TITLE
92 junit categories 2

### DIFF
--- a/infinitest-runner/pom.xml
+++ b/infinitest-runner/pom.xml
@@ -97,6 +97,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/JUnit4Runner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/JUnit4Runner.java
@@ -95,7 +95,7 @@ public class JUnit4Runner implements NativeRunner {
 	}
 
 	private TestResults runJUnitTest(Class<?> classUnderTest) {
-		EventTranslator eventTranslator = new EventTranslator();
+		JUnitEventTranslator eventTranslator = new JUnitEventTranslator();
 
 		JUnitCore core = new JUnitCore();
 		core.addListener(eventTranslator);
@@ -114,7 +114,9 @@ public class JUnit4Runner implements NativeRunner {
 
 		Class<?>[] junitCategoriesToExclude = readExcludedGroupsFromConfiguration();
 
-		return request.filterWith(CategoryFilter.exclude(junitCategoriesToExclude));
+		CategoryFilter excludeCategoriesFilter = CategoryFilter.exclude(junitCategoriesToExclude);
+
+		return request.filterWith(excludeCategoriesFilter);
 	}
 
 	/**

--- a/infinitest-runner/src/test/java/org/infinitest/TestNGConfiguratorTest.java
+++ b/infinitest-runner/src/test/java/org/infinitest/TestNGConfiguratorTest.java
@@ -29,19 +29,15 @@ package org.infinitest;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.io.*;
 import java.util.*;
 
-import org.infinitest.config.InfinitestConfiguration;
-import org.infinitest.config.MemoryInfinitestConfigurationSource;
+import org.infinitest.config.*;
 import org.junit.*;
-import org.junit.rules.TemporaryFolder;
+import org.junit.rules.*;
 
 public class TestNGConfiguratorTest {
-	TestNGConfigurator configurator = new TestNGConfigurator();
 
-	@Rule
-	public TemporaryFolder temp = new TemporaryFolder();
+	@Rule public TemporaryFolder temp = new TemporaryFolder();
 
 	@Test
 	public void emptyConfigShouldConvertToEmptyExcludedGroups() {
@@ -63,37 +59,28 @@ public class TestNGConfiguratorTest {
 
 	@Test
 	public void groupsShouldBeJoinedAsACommaSeparatedList() {
-		TestNGConfiguration config = fromInfinitestConfig(
-				InfinitestConfiguration.builder().includedGroups("quick", "smoketests").build());
+		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder().includedGroups("quick", "smoketests").build());
 		assertThat(config.getGroups()).isEqualTo("quick,smoketests");
 	}
 
 	@Test
 	public void excludedGroupsShouldBeJoinedAsACommaSeparatedList() {
-		TestNGConfiguration config = fromInfinitestConfig(
-				InfinitestConfiguration.builder().excludedGroups("slow", "broken", "manual").build());
+		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder().excludedGroups("slow", "broken", "manual").build());
 		assertThat(config.getExcludedGroups()).isEqualTo("slow,broken,manual");
 	}
 
 	@Test
 	public void listenersClassesShouldBeInstantiated() {
-		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder()
-				.testngListeners(
-						"org.testng.internal.annotations.DefaultAnnotationTransformer", "org.testng.reporters.JUnitXMLReporter")
-				.build());
+		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder().testngListeners("org.testng.internal.annotations.DefaultAnnotationTransformer", "org.testng.reporters.JUnitXMLReporter").build());
 		List<Object> listeners = config.getListeners();
 
-		assertThat(listeners.get(0))
-				.isExactlyInstanceOf(org.testng.internal.annotations.DefaultAnnotationTransformer.class);
+		assertThat(listeners.get(0)).isExactlyInstanceOf(org.testng.internal.annotations.DefaultAnnotationTransformer.class);
 		assertThat(listeners.get(1)).isExactlyInstanceOf(org.testng.reporters.JUnitXMLReporter.class);
 	}
 
 	@Test
 	public void unknowListenersClassesShouldBeIgnored() {
-		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder()
-				.testngListeners(
-						"org.testng.UnknownReporter", "org.testng.reporters.JUnitXMLReporter")
-				.build());
+		TestNGConfiguration config = fromInfinitestConfig(InfinitestConfiguration.builder().testngListeners("org.testng.UnknownReporter", "org.testng.reporters.JUnitXMLReporter").build());
 		List<Object> listeners = config.getListeners();
 
 		assertThat(listeners.get(0)).isExactlyInstanceOf(org.testng.reporters.JUnitXMLReporter.class);

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/FailingTestsWithCategories.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/FailingTestsWithCategories.java
@@ -1,0 +1,59 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.testrunner;
+
+import static org.junit.Assert.*;
+
+import org.junit.*;
+import org.junit.experimental.categories.*;
+
+public class FailingTestsWithCategories {
+
+	interface IgnoreMe {
+	}
+
+	interface IgnoreMeToo {
+	}
+
+	@Test
+	public void shouldBeTested() {
+		fail();
+	}
+
+	@Category(IgnoreMe.class)
+	@Test
+	public void shouldNotBeTested() {
+		fail();
+	}
+
+	@Category(IgnoreMeToo.class)
+	@Test
+	public void shouldAlsoNotBeTested() {
+		fail();
+	}
+}

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/FailingTestsWithCategories.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/FailingTestsWithCategories.java
@@ -40,19 +40,23 @@ public class FailingTestsWithCategories {
 	interface IgnoreMeToo {
 	}
 
+	interface UsuallyRunMe {
+	}
+
 	@Test
+	@Category(UsuallyRunMe.class)
 	public void shouldBeTested() {
 		fail();
 	}
 
-	@Category(IgnoreMe.class)
 	@Test
+	@Category(IgnoreMe.class)
 	public void shouldNotBeTested() {
 		fail();
 	}
 
-	@Category(IgnoreMeToo.class)
 	@Test
+	@Category(IgnoreMeToo.class)
 	public void shouldAlsoNotBeTested() {
 		fail();
 	}

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenConvertingJUnitEventsToInfinitestEvents.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenConvertingJUnitEventsToInfinitestEvents.java
@@ -37,7 +37,7 @@ import org.junit.runner.*;
 import org.junit.runner.notification.*;
 
 public class WhenConvertingJUnitEventsToInfinitestEvents {
-	private EventTranslator eventTranslator;
+	private JUnitEventTranslator eventTranslator;
 	private Result result;
 	private Description description;
 	private StubClock stubClock;
@@ -45,7 +45,7 @@ public class WhenConvertingJUnitEventsToInfinitestEvents {
 	@Before
 	public void inContext() throws Exception {
 		stubClock = new StubClock();
-		eventTranslator = new EventTranslator(stubClock);
+		eventTranslator = new JUnitEventTranslator(stubClock);
 		description = createTestDescription(getClass(), "methodName");
 		eventTranslator.testRunStarted(description);
 		result = new Result();

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningJUnitTests.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningJUnitTests.java
@@ -32,11 +32,14 @@ import static org.infinitest.testrunner.TestEvent.*;
 import static org.junit.Assert.*;
 
 import org.infinitest.*;
+import org.infinitest.config.*;
+import org.infinitest.testrunner.FailingTestsWithCategories.*;
 import org.infinitest.testrunner.exampletests.*;
 //import org.infinitest.testrunner.testables.*;
 import org.junit.*;
 
 public class WhenRunningJUnitTests {
+	private static final String[] EMPTY = new String[0];
 	private JUnit4Runner runner;
 	private static final Class<?> TEST_CLASS = TestThatThrowsExceptionInConstructor.class;
 
@@ -112,6 +115,33 @@ public class WhenRunningJUnitTests {
 		assertEventsEquals(expectedEvent, getOnlyElement(events));
 	}
 
+	@Test
+	public void shouldExecuteAllTestsIfNoExcludedCategories() {
+		runner.setTestConfigurationSource(withExcludedGroups(EMPTY));
+
+		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
+
+		assertEquals(3, size(results));
+	}
+
+	@Test
+	public void shouldNotExecuteTestInOneExcludedCategory() {
+		runner.setTestConfigurationSource(withExcludedGroups(IgnoreMe.class.getName()));
+
+		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
+
+		assertEquals(2, size(results));
+	}
+
+	@Test
+	public void shouldNotExecuteTestInAnyExcludedCategories() {
+		runner.setTestConfigurationSource(withExcludedGroups(IgnoreMe.class.getName(), IgnoreMeToo.class.getName()));
+
+		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
+
+		assertEquals(1, size(results));
+	}
+
 	private void assertEventsEquals(TestEvent expected, TestEvent actual) {
 		assertEquals(expected, actual);
 		assertEquals(expected.getMessage(), actual.getMessage());
@@ -122,4 +152,11 @@ public class WhenRunningJUnitTests {
 	public void testCaseStarting(TestEvent event) {
 		fail("Native runner should never fire this");
 	}
+
+	private MemoryInfinitestConfigurationSource withExcludedGroups(String... excludedGroups) {
+		InfinitestConfiguration configuration = InfinitestConfiguration.builder().excludedGroups(excludedGroups).build();
+
+		return new MemoryInfinitestConfigurationSource(configuration);
+	}
+
 }

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningJUnitTests.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/WhenRunningJUnitTests.java
@@ -28,6 +28,8 @@
 package org.infinitest.testrunner;
 
 import static com.google.common.collect.Iterables.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.infinitest.testrunner.TestEvent.*;
 import static org.junit.Assert.*;
 
@@ -121,7 +123,7 @@ public class WhenRunningJUnitTests {
 
 		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
 
-		assertEquals(3, size(results));
+		assertThat(size(results), is(3));
 	}
 
 	@Test
@@ -130,7 +132,7 @@ public class WhenRunningJUnitTests {
 
 		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
 
-		assertEquals(2, size(results));
+		assertThat(size(results), is(2));
 	}
 
 	@Test
@@ -139,7 +141,17 @@ public class WhenRunningJUnitTests {
 
 		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
 
-		assertEquals(1, size(results));
+		assertThat(size(results), is(1));
+	}
+
+	@Test
+	public void shouldNotRunAnyTestsIfAllAreExcluded() throws Exception {
+		String[] allCategories = { IgnoreMe.class.getName(), IgnoreMeToo.class.getName(), UsuallyRunMe.class.getName() };
+		runner.setTestConfigurationSource(withExcludedGroups(allCategories));
+
+		TestResults results = runner.runTest(FailingTestsWithCategories.class.getName());
+
+		assertThat(results, is(emptyIterable()));
 	}
 
 	private void assertEventsEquals(TestEvent expected, TestEvent actual) {
@@ -158,5 +170,4 @@ public class WhenRunningJUnitTests {
 
 		return new MemoryInfinitestConfigurationSource(configuration);
 	}
-
 }


### PR DESCRIPTION
Solves issue #92. 

Specifying a JUnit category in the 'excludeGroups' entry of infinitest.filters will cause infinitest to ignore any test annotated with `@Category(TheCategoryToIgnore.class)`.

Replaces pull request #160 which was based on code too old to be worth updating.  Yeah, sorry it took me  2 years, 6 months, and 10 days to complete. :|