### PR TITLE
Handle CatgegoryFilter being different in 4.12

### DIFF
--- a/testWorkspace/mavenproject/pom.xml
+++ b/testWorkspace/mavenproject/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.7</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
    


### PR DESCRIPTION
Guard the category filter with a check. If no excludes are defined, just
skip the whole category filter, otherwise, if there's an error creating
the filter then throw an exception since that only happens in Junit
<4.12

This fixes #265