### PR TITLE
285 - format xml to avoid class loading issue by intellij

### DIFF
--- a/infinitest-intellij/src/main/resources/META-INF/plugin.xml
+++ b/infinitest-intellij/src/main/resources/META-INF/plugin.xml
@@ -13,14 +13,12 @@
     </application-components>
     <project-components>
         <component>
-            <implementation-class>org.infinitest.intellij.idea.language.InfinitestHighlightingPassFactory
-            </implementation-class>
+            <implementation-class>org.infinitest.intellij.idea.language.InfinitestHighlightingPassFactory</implementation-class>
         </component>
     </project-components>
     <module-components>
         <component>
-            <implementation-class>org.infinitest.intellij.idea.window.InfinitestToolWindow
-            </implementation-class>
+            <implementation-class>org.infinitest.intellij.idea.window.InfinitestToolWindow</implementation-class>
         </component>
     </module-components>
 </idea-plugin>


### PR DESCRIPTION
Intellij is trying to find a class on the classpath with the line break, which causes a class not found exception.

So, I just removed the line breaks.