### PR TITLE
deps: removed obsolete dependencies

### DIFF
--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -88,11 +88,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.picocontainer</groupId>
-      <artifactId>picocontainer</artifactId>
-      <version>2.15</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
@@ -154,20 +149,11 @@
       <version>1.0</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
+
     <dependency>
       <groupId>org.infinitest</groupId>
       <artifactId>infinitest-lib</artifactId>
       <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sanselan</groupId>
-      <artifactId>sanselan</artifactId>
-      <version>0.97-incubator</version>
     </dependency>
   </dependencies>
 </project>

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/ModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/ModuleSettings.java
@@ -27,9 +27,9 @@
  */
 package org.infinitest.intellij;
 
-import org.apache.log4j.*;
-import org.infinitest.*;
 import org.infinitest.environment.RuntimeEnvironment;
+
+import com.intellij.openapi.diagnostic.Logger;
 
 public interface ModuleSettings {
 	void writeToLogger(Logger log);

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.intellij.InfinitestJarsLocator;
 import org.infinitest.intellij.ModuleSettings;
@@ -45,6 +44,7 @@ import org.testng.collections.Lists;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.compiler.CompilerPaths;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/InfinitestLauncherImpl.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/InfinitestLauncherImpl.java
@@ -31,7 +31,6 @@ import java.awt.*;
 
 import javax.swing.*;
 
-import org.apache.log4j.*;
 import org.infinitest.*;
 import org.infinitest.intellij.*;
 import org.infinitest.intellij.idea.*;
@@ -39,6 +38,7 @@ import org.infinitest.intellij.plugin.*;
 import org.infinitest.intellij.plugin.swingui.*;
 import org.infinitest.util.*;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.*;
 import com.intellij.openapi.wm.*;
 
@@ -64,7 +64,7 @@ public class InfinitestLauncherImpl implements InfinitestLauncher {
 
 	@Override
 	public void launchInfinitest() {
-		moduleSettings.writeToLogger(Logger.getLogger(getClass()));
+		moduleSettings.writeToLogger(Logger.getFactory().getLoggerInstance(getClass().getName()));
 
 		testControl = new IdeaCompilationListener(infinitestBuilder.getCore(), moduleSettings);
 		initializeInfinitestLogging();

--- a/infinitest-intellij/src/main/resources/META-INF/maven/org.infinitest/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/src/main/resources/META-INF/maven/org.infinitest/infinitest-intellij/pom.xml
@@ -12,11 +12,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
-        </dependency>
-        <dependency>
             <groupId>org.infinitest</groupId>
             <artifactId>infinitest-lib</artifactId>
             <version>5.2.1-SNAPSHOT</version>

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/FakeModuleSettings.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/FakeModuleSettings.java
@@ -34,8 +34,9 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.infinitest.environment.RuntimeEnvironment;
+
+import com.intellij.openapi.diagnostic.Logger;
 
 public class FakeModuleSettings implements ModuleSettings {
 	private final String name;


### PR DESCRIPTION
- picocontainer seems unused
- log4j 1.2 is unmaintained and has vulnerabilities, replace it with IntelliJ's built-in logger
- sanselan is unmaintained and has vulnerabilities, it seems unused