### PR TITLE
feature: support for JUnit 5 combined annotations

### DIFF
--- a/infinitest-lib/pom.xml
+++ b/infinitest-lib/pom.xml
@@ -71,6 +71,13 @@
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit5.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit5.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
@@ -297,14 +297,14 @@ public class JavaAssistClass extends AbstractJavaClass {
                 .flatMap(Arrays::stream)
                 .anyMatch(annotation -> isJUnit5TestAnnotation(annotation, classPool));
     }
-    
-    /**
-     * @return <code>true</code> if the annotation is JUnit's <code>Test</code> or if the annotation type itself is annotated
-     * with <code>Test</code> or <code>TestTemplate</code>. Annotations such as <code>ParameterizedTest<code> are annotated with
-     * <code>TestTemplate</code> and should be detected as tests
-     */
-    private boolean isJUnit5TestAnnotation(Annotation annotation, ClassPool classPool) {
-    	String annotationTypeName = annotation.getTypeName();
+	
+	/**
+	 * @return <code>true</code> if the annotation is JUnit's <code>Test</code> or if the annotation type itself is annotated
+	 * with <code>Test</code> or <code>TestTemplate</code>. Annotations such as <code>ParameterizedTest<code> are annotated with
+	 * <code>TestTemplate</code> and should be detected as tests
+	 */
+	private boolean isJUnit5TestAnnotation(Annotation annotation, ClassPool classPool) {
+		String annotationTypeName = annotation.getTypeName();
 		boolean isJUnitTestAnnotation = org.junit.jupiter.api.Test.class.getName().equals(annotationTypeName);
 		
 		if (isJUnitTestAnnotation) {

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5CompositeAnnotation.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5CompositeAnnotation.java
@@ -1,0 +1,41 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.fakeco.fakeproduct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Test;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+public @interface JUnit5CompositeAnnotation {
+}

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5CompositeAnnotationTest.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5CompositeAnnotationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.fakeco.fakeproduct;
+
+import static org.junit.Assert.fail;
+
+public class JUnit5CompositeAnnotationTest {
+	@JUnit5CompositeAnnotation
+	void check() {
+		fail("Just a test");
+	}
+}

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ParameterizedTest.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ParameterizedTest.java
@@ -1,0 +1,40 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.fakeco.fakeproduct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class JUnit5ParameterizedTest {
+	@org.junit.jupiter.params.ParameterizedTest
+	@ValueSource(ints = {0,1,2})
+	void check(int x) {
+		assertEquals(0, 1, "x should be 1");
+	}
+}

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTest.java
@@ -124,4 +124,22 @@ public class JavaAssistClassTest {
 	private String[] dependenciesOf(Class<?> dependingClass) {
 		return classPoolUtil.dependenciesOf(dependingClass);
 	}
+	
+	@Test
+	public void shouldSupportParameterizedTest() throws NotFoundException {
+		ClassPool classPool = classPoolUtil.getClassPool();
+		CtClass ctClass = classPool.get(JUnit5ParameterizedTest.class.getName());
+		JavaAssistClass javaClass = new JavaAssistClass(ctClass);
+		
+		assertTrue(javaClass.isATest());
+	}
+	
+	@Test
+	public void shouldSupportCompositeTestAnnotation() throws NotFoundException {
+		ClassPool classPool = classPoolUtil.getClassPool();
+		CtClass ctClass = classPool.get(JUnit5CompositeAnnotationTest.class.getName());
+		JavaAssistClass javaClass = new JavaAssistClass(ctClass);
+		
+		assertTrue(javaClass.isATest());
+	}
 }

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/JUnit5RunnerTest.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/JUnit5RunnerTest.java
@@ -42,6 +42,7 @@ import org.infinitest.config.MemoryInfinitestConfigurationSource;
 import org.infinitest.testrunner.exampletests.junit4.Junit4PassingTestCase;
 import org.infinitest.testrunner.exampletests.junit5.JUnit5DisabledTest;
 import org.infinitest.testrunner.exampletests.junit5.JUnit5Test;
+import org.infinitest.testrunner.exampletests.junit5.JUnit5TestUsingComposedAnnotation;
 import org.infinitest.testrunner.exampletests.junit5.JUnit5TestUsingTag;
 import org.infinitest.testrunner.junit5.Junit5Runner;
 import org.junit.After;
@@ -118,5 +119,15 @@ public class JUnit5RunnerTest {
 		assertThat(failedMethodNames).contains("tag2");
 		assertThat(failedMethodNames).doesNotContain("tag1", "noTag", "tag1And2");
 
+	}
+	
+	@Test
+	public void shouldSupportCombinedAnnotation() {
+		assertTrue(Junit5Runner.isJUnit5Test(JUnit5TestUsingComposedAnnotation.class));
+		
+		Iterable<TestEvent> events = runner.runTest(JUnit5TestUsingComposedAnnotation.class.getName());
+		Set<String> failedMethodNames = failedMethodNames(events);
+
+		assertThat(failedMethodNames).contains("fastTest");
 	}
 }

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/exampletests/junit5/FastTestCombinedAnnotation.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/exampletests/junit5/FastTestCombinedAnnotation.java
@@ -1,0 +1,43 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.testrunner.exampletests.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("fast")
+@Test
+public @interface FastTestCombinedAnnotation {
+}

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/exampletests/junit5/JUnit5TestUsingComposedAnnotation.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/exampletests/junit5/JUnit5TestUsingComposedAnnotation.java
@@ -1,0 +1,38 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.testrunner.exampletests.junit5;
+
+import org.junit.jupiter.api.Assertions;
+
+public class JUnit5TestUsingComposedAnnotation {
+
+	@FastTestCombinedAnnotation
+	public void fastTest() {
+		Assertions.fail("failure");
+	}
+}


### PR DESCRIPTION
Adds support for JUnit5 combined annotation: https://junit.org/junit5/docs/current/user-guide/#writing-tests-meta-annotations

- When checking if a method is a test, look for combined annotations
- Look for annotations that are themselves annotated with `TestTemplate `to support `ParameterizedTest`
- Added sample classes covering the new cases

Fixes #276
Fixes #268