### PR TITLE
fix: keep track of the HighlightingPass

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
@@ -33,9 +33,14 @@ import com.intellij.codeHighlighting.*;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.module.*;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.Key;
 import com.intellij.psi.*;
 
 public class InfinitestHighlightingPassFactory implements TextEditorHighlightingPassFactory {
+	/**
+	 * The key to retrieve the {@link InfinitestLineMarkersPass} in the {@link Editor}
+	 */
+	public static final Key<InfinitestLineMarkersPass> KEY = new Key<>("InfinitestLineMarkersPass");
 
 	public InfinitestHighlightingPassFactory(TextEditorHighlightingPassRegistrar passRegistrar) {
 		passRegistrar.registerTextEditorHighlightingPass(this, TextEditorHighlightingPassRegistrar.Anchor.LAST, Pass.UPDATE_ALL, true, true);
@@ -48,6 +53,9 @@ public class InfinitestHighlightingPassFactory implements TextEditorHighlighting
 			return null;
 		}
 
-		return new InfinitestLineMarkersPass(module.getProject(), editor.getDocument(), editor.getMarkupModel());
+		InfinitestLineMarkersPass pass = new InfinitestLineMarkersPass(module.getProject(), editor.getDocument(), editor.getMarkupModel());
+		editor.putUserData(KEY, pass);
+		
+		return pass;
 	}
 }

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/FileEditorListener.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/FileEditorListener.java
@@ -27,8 +27,13 @@
  */
 package org.infinitest.intellij.plugin.launcher;
 
-import com.intellij.codeHighlighting.*;
-import com.intellij.openapi.fileEditor.*;
+import org.infinitest.intellij.idea.language.InfinitestHighlightingPassFactory;
+import org.infinitest.intellij.idea.language.InfinitestLineMarkersPass;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
 
 public class FileEditorListener implements PresenterListener {
 	FileEditorManager fileEditorManager;
@@ -40,8 +45,15 @@ public class FileEditorListener implements PresenterListener {
 	@Override
 	public void testRunCompleted() {
 		for (FileEditor fileEditor : fileEditorManager.getSelectedEditors()) {
-			for (HighlightingPass highlightingPass : fileEditor.getBackgroundHighlighter().createPassesForEditor()) {
-				highlightingPass.applyInformationToEditor();
+			if (fileEditor instanceof TextEditor) {
+				TextEditor textEditor = (TextEditor) fileEditor;
+				Editor editor = textEditor.getEditor();
+				
+				InfinitestLineMarkersPass pass = editor.getUserData(InfinitestHighlightingPassFactory.KEY);
+
+				if (pass != null) {
+					pass.applyInformationToEditor();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Store the pass in the editor instead of calling fileEditor.getBackgroundHighlighter().createPassesForEditor(), that method recreates the passes and must not be called from the EDT while highlightingPass.applyInformationToEditor() must be called from the EDT.

fixes #233
fixes #274