### PR TITLE
deps: align the jcommander version with the unpacked version

### DIFF
--- a/infinitest-runner/pom.xml
+++ b/infinitest-runner/pom.xml
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.30</version>
+      <version>1.35</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<testng.version>6.8.8</testng.version>
 		<assertj.version>3.9.0</assertj.version>
 		<autovalue.version>1.3</autovalue.version>
+		<jcommander.version>1.35</jcommander.version>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
Fixes #273 