### PR TITLE
release 5.3.0

### DIFF
--- a/infinitest-classloader/pom.xml
+++ b/infinitest-classloader/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.infinitest</groupId>
     <artifactId>infinitest-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.3.0</version>
   </parent>
 
   <name>Infinitest ClassLoader</name>

--- a/infinitest-eclipse/pom.xml
+++ b/infinitest-eclipse/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.infinitest</groupId>
 		<artifactId>infinitest-parent</artifactId>
-		<version>5.2.1-SNAPSHOT</version>
+		<version>5.3.0</version>
 	</parent>
 
 	<name>Infinitest Plugin for Eclipse</name>

--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.infinitest</groupId>
     <artifactId>infinitest-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.3.0</version>
   </parent>
 
   <name>Infinitest for IntelliJ</name>

--- a/infinitest-intellij/src/main/resources/META-INF/maven/org.infinitest/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/src/main/resources/META-INF/maven/org.infinitest/infinitest-intellij/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.infinitest</groupId>
             <artifactId>infinitest-lib</artifactId>
-            <version>5.2.1-SNAPSHOT</version>
+            <version>5.3.0</version>
         </dependency>
     </dependencies>
 

--- a/infinitest-lib/pom.xml
+++ b/infinitest-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.infinitest</groupId>
 		<artifactId>infinitest-parent</artifactId>
-		<version>5.2.1-SNAPSHOT</version>
+		<version>5.3.0</version>
 	</parent>
 
 	<name>Infinitest Lib</name>

--- a/infinitest-runner/pom.xml
+++ b/infinitest-runner/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.infinitest</groupId>
     <artifactId>infinitest-parent</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.3.0</version>
   </parent>
 
   <name>Infinitest Runner</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>infinitest-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>Infinitest Parent POM</name>
-	<version>5.2.1-SNAPSHOT</version>
+	<version>5.3.0</version>
 	<url>http://infinitest.github.com/</url>
 
 	<modules>


### PR DESCRIPTION
We should be good to release a new version now:
- The blocking dependencies have been upgraded
- A new GitHub action build [release.yml](https://github.com/infinitest/infinitest/blob/master/.github/workflows/release.yml) has been added to build and sign the plugins
- The [CONTRIBUTING.md](https://github.com/infinitest/infinitest/blob/master/CONTRIBUTING.md) file has been updated with the new process
- The upload of the Eclipse and IntelliJ plugins is not automated for now, so it must be done manually

It might take a couple of tries to get the workflow to build so I'll commit the new SNAPSHOT version later

Fixes #279 
Fixes #297