### PR TITLE
fix: replacing the system classloader prevents instrumentation

### DIFF
--- a/infinitest-lib/src/main/java/org/infinitest/environment/ClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/ClasspathArgumentBuilder.java
@@ -31,7 +31,13 @@ import java.util.List;
 
 public interface ClasspathArgumentBuilder {
 
+	/**
+	 * @return the command line argument(s) for the classpath
+	 */
 	List<String> buildArguments();
 
-	void cleanUp();
+	/**
+	 * Called when the runner process is aborted
+	 */
+	void cleanup();
 }

--- a/infinitest-lib/src/main/java/org/infinitest/environment/ClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/ClasspathArgumentBuilder.java
@@ -25,41 +25,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.testrunner.process;
+package org.infinitest.environment;
 
-import org.infinitest.environment.ClasspathArgumentBuilder;
-import org.infinitest.testrunner.TestResults;
+import java.util.List;
 
-public class NativeProcessConnection implements ProcessConnection {
-	private final TcpSocketProcessCommunicator communicator;
-	private final Process process;
-	private final ClasspathArgumentBuilder classpathArgumentBuilder;
+public interface ClasspathArgumentBuilder {
 
-	public NativeProcessConnection(TcpSocketProcessCommunicator communicator, Process process, ClasspathArgumentBuilder classpathArgumentBuilder) {
-		this.communicator = communicator;
-		this.process = process;
-		this.classpathArgumentBuilder = classpathArgumentBuilder;
-	}
+	List<String> buildArguments();
 
-	@Override
-	public boolean abort() {
-		classpathArgumentBuilder.cleanUp();
-		process.destroy();
-		try {
-			process.waitFor();
-		} catch (InterruptedException e) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public void close() {
-		communicator.closeSocket();
-	}
-
-	@Override
-	public TestResults runTest(String testName) {
-		return communicator.sendMessage(testName);
-	}
+	void cleanUp();
 }

--- a/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
@@ -41,7 +41,7 @@ public class FileClasspathArgumentBuilder implements ClasspathArgumentBuilder {
 
 	@Override
 	public List<String> buildArguments() {
-		return Arrays.asList("-cp", "@" + classpathFile.getAbsolutePath());
+		return Arrays.asList("-cp", "@\"" + classpathFile.getAbsolutePath() + "\"");
 	}
 	
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
@@ -41,7 +41,7 @@ public class FileClasspathArgumentBuilder implements ClasspathArgumentBuilder {
 
 	@Override
 	public List<String> buildArguments() {
-		return Arrays.asList("-cp", "@\"" + classpathFile.getAbsolutePath() + "\"");
+		return Arrays.asList("-cp", "@" + classpathFile.getAbsolutePath());
 	}
 	
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
@@ -45,7 +45,7 @@ public class FileClasspathArgumentBuilder implements ClasspathArgumentBuilder {
 	}
 	
 	@Override
-	public void cleanUp() {
+	public void cleanup() {
 		classpathFile.delete();
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/FileClasspathArgumentBuilder.java
@@ -25,41 +25,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.testrunner.process;
+package org.infinitest.environment;
 
-import org.infinitest.environment.ClasspathArgumentBuilder;
-import org.infinitest.testrunner.TestResults;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
-public class NativeProcessConnection implements ProcessConnection {
-	private final TcpSocketProcessCommunicator communicator;
-	private final Process process;
-	private final ClasspathArgumentBuilder classpathArgumentBuilder;
+public class FileClasspathArgumentBuilder implements ClasspathArgumentBuilder {
 
-	public NativeProcessConnection(TcpSocketProcessCommunicator communicator, Process process, ClasspathArgumentBuilder classpathArgumentBuilder) {
-		this.communicator = communicator;
-		this.process = process;
-		this.classpathArgumentBuilder = classpathArgumentBuilder;
+	private File classpathFile;
+
+	public FileClasspathArgumentBuilder(File classpathFile) {
+		this.classpathFile = classpathFile;
 	}
 
 	@Override
-	public boolean abort() {
-		classpathArgumentBuilder.cleanUp();
-		process.destroy();
-		try {
-			process.waitFor();
-		} catch (InterruptedException e) {
-			return false;
-		}
-		return true;
+	public List<String> buildArguments() {
+		return Arrays.asList("-cp", "@" + classpathFile.getAbsolutePath());
 	}
-
+	
 	@Override
-	public void close() {
-		communicator.closeSocket();
-	}
-
-	@Override
-	public TestResults runTest(String testName) {
-		return communicator.sendMessage(testName);
+	public void cleanUp() {
+		classpathFile.delete();
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
@@ -298,16 +298,26 @@ public class RuntimeEnvironment implements ClasspathProvider {
 	 * @return The Java major version (e.g 8 for 8.xyz) or null if we could not get the version
 	 */
 	private Integer getJavaVersion() {
-		Properties properties = new Properties();
+		String javaVersion = null;
+		
 		try (FileInputStream in = new FileInputStream(new File(javaHome, "release"))) {
+			Properties properties = new Properties();
 			properties.load(in);
 			
-			String javaVersion = properties.getProperty("JAVA_VERSION");
-			String javaMajorVersion = javaVersion.substring(1, javaVersion.indexOf('.'));
+			javaVersion = properties.getProperty("JAVA_VERSION");
+			int indexOfPoint = javaVersion.indexOf('.');
+			String javaMajorVersion;
+			if (indexOfPoint == -1) {
+				// For the reference OpenJDK build the version is "18"
+				javaMajorVersion = javaVersion.substring(1, javaVersion.length() - 1);
+			} else {
+				// For temurin it is "18.0.2"
+				javaMajorVersion = javaVersion.substring(1, indexOfPoint);
+			}
 			
 			return Integer.parseInt(javaMajorVersion);
-		} catch (IOException e) {
-			log(Level.SEVERE, "Could not get java version " + e.getClass() + " " + e.getMessage());
+		} catch (Exception e) {
+			log(Level.SEVERE, "Could not get java version (" + javaVersion + ") " + e.getClass() + " " + e.getMessage());
 			return null;
 		}
 	}

--- a/infinitest-lib/src/main/java/org/infinitest/environment/SimpleClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/SimpleClasspathArgumentBuilder.java
@@ -43,7 +43,7 @@ public class SimpleClasspathArgumentBuilder implements ClasspathArgumentBuilder 
 	}
 
 	@Override
-	public void cleanUp() {
+	public void cleanup() {
 		// Nothing to clean up here
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/environment/SimpleClasspathArgumentBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/SimpleClasspathArgumentBuilder.java
@@ -25,41 +25,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.testrunner.process;
+package org.infinitest.environment;
 
-import org.infinitest.environment.ClasspathArgumentBuilder;
-import org.infinitest.testrunner.TestResults;
+import java.util.Arrays;
+import java.util.List;
 
-public class NativeProcessConnection implements ProcessConnection {
-	private final TcpSocketProcessCommunicator communicator;
-	private final Process process;
-	private final ClasspathArgumentBuilder classpathArgumentBuilder;
-
-	public NativeProcessConnection(TcpSocketProcessCommunicator communicator, Process process, ClasspathArgumentBuilder classpathArgumentBuilder) {
-		this.communicator = communicator;
-		this.process = process;
-		this.classpathArgumentBuilder = classpathArgumentBuilder;
+public class SimpleClasspathArgumentBuilder implements ClasspathArgumentBuilder {
+	private String classpath;
+	
+	public SimpleClasspathArgumentBuilder(String classpath) {
+		this.classpath = classpath;
 	}
 
 	@Override
-	public boolean abort() {
-		classpathArgumentBuilder.cleanUp();
-		process.destroy();
-		try {
-			process.waitFor();
-		} catch (InterruptedException e) {
-			return false;
-		}
-		return true;
+	public List<String> buildArguments() {
+		return Arrays.asList("-cp", classpath);
 	}
 
 	@Override
-	public void close() {
-		communicator.closeSocket();
-	}
-
-	@Override
-	public TestResults runTest(String testName) {
-		return communicator.sendMessage(testName);
+	public void cleanUp() {
+		// Nothing to clean up here
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeConnectionFactory.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeConnectionFactory.java
@@ -31,13 +31,13 @@ import static java.util.Arrays.asList;
 import static java.util.logging.Level.INFO;
 import static org.infinitest.util.InfinitestUtils.log;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.infinitest.ConsoleOutputListener.OutputType;
+import org.infinitest.environment.ClasspathArgumentBuilder;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.testrunner.NativeRunner;
 import org.infinitest.testrunner.OutputStreamHandler;
@@ -54,13 +54,13 @@ public class NativeConnectionFactory implements ProcessConnectionFactory {
 	public ProcessConnection getConnection(RuntimeEnvironment environment, OutputStreamHandler outputListener) throws IOException {
 		TcpSocketProcessCommunicator communicator = createCommunicator();
 				
-		File classpathFile = environment.createClasspathFile();
+		ClasspathArgumentBuilder classpathArgumentBuilder = environment.createClasspathArgumentBuilder();
 		
-		Process process = startProcess(communicator.createSocket(), environment, classpathFile);
+		Process process = startProcess(communicator.createSocket(), environment, classpathArgumentBuilder);
 		outputListener.processStream(process.getErrorStream(), OutputType.STDERR);
 		outputListener.processStream(process.getInputStream(), OutputType.STDOUT);
 		communicator.openSocket();
-		return new NativeProcessConnection(communicator, process, classpathFile);
+		return new NativeProcessConnection(communicator, process, classpathArgumentBuilder);
 	}
 
 
@@ -69,9 +69,9 @@ public class NativeConnectionFactory implements ProcessConnectionFactory {
 		return new TcpSocketProcessCommunicator();
 	}
 
-	Process startProcess(int port, RuntimeEnvironment environment, File classPathFile) throws IOException {
+	Process startProcess(int port, RuntimeEnvironment environment, ClasspathArgumentBuilder classpathArgumentBuilder) throws IOException {
 		
-		ProcessBuilder builder = buildProcess(port, environment, classPathFile);
+		ProcessBuilder builder = buildProcess(port, environment, classpathArgumentBuilder);
 		log(INFO, "Starting TestRunner with configuration:\n"+buildTestProcessConfigurationMessage(builder));
 		try {
 			return builder.start();
@@ -81,13 +81,13 @@ public class NativeConnectionFactory implements ProcessConnectionFactory {
 		}
 	}
 
-	ProcessBuilder buildProcess(int port, RuntimeEnvironment environment, File classPathFile) {
+	ProcessBuilder buildProcess(int port, RuntimeEnvironment environment, ClasspathArgumentBuilder classpathArgumentBuilder) {
 		// Could extract this to a class. Could then replace with:
 		// http://wiki.eclipse.org/FAQ_How_do_I_launch_a_Java_program%3F
 		ProcessBuilder builder = new ProcessBuilder();
 		builder.directory(environment.getWorkingDirectory());
 
-		List<String> arguments = environment.createProcessArguments(classPathFile);
+		List<String> arguments = environment.createProcessArguments(classpathArgumentBuilder);
 		arguments.addAll(buildRunnerArgs(port));
 		builder.command(arguments);
 

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeProcessConnection.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeProcessConnection.java
@@ -43,7 +43,7 @@ public class NativeProcessConnection implements ProcessConnection {
 
 	@Override
 	public boolean abort() {
-		classpathArgumentBuilder.cleanUp();
+		classpathArgumentBuilder.cleanup();
 		process.destroy();
 		try {
 			process.waitFor();

--- a/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.util.Arrays;
@@ -113,7 +114,8 @@ public class RuntimeEnvironmentTest {
 				"runnerClassLoaderClassPath", "runnerProcessClassPath", fakeBuildPaths(),
 				FakeEnvironments.systemClasspath());
 		try {
-			environment.createProcessArguments(new File("file.classpath"));
+			ClasspathArgumentBuilder classpathArgumentBuilder = mock(ClasspathArgumentBuilder.class);
+			environment.createProcessArguments(classpathArgumentBuilder);
 			fail("Should have thrown exception");
 		} catch (JavaHomeException e) {
 			assertThat(convertFromWindowsClassPath(e.getMessage()))
@@ -128,12 +130,13 @@ public class RuntimeEnvironmentTest {
 				FakeEnvironments.systemClasspath());
 
 		touch(new File(fakeJavaHomeRule.getRoot(), "bin/java.exe"));
-		List<String> arguments = environment.createProcessArguments(new File("file.classpath"));
+		ClasspathArgumentBuilder classpathArgumentBuilder = mock(ClasspathArgumentBuilder.class);
+		List<String> arguments = environment.createProcessArguments(classpathArgumentBuilder);
 		assertEquals(convertFromWindowsClassPath(fakeJavaHomeRule.getRoot().getAbsolutePath()) + "/bin/java.exe",
 				convertFromWindowsClassPath(get(arguments, 0)));
 
 		touch(new File(fakeJavaHomeRule.getRoot(), "bin/java"));
-		arguments = environment.createProcessArguments(new File("file.classpath"));
+		arguments = environment.createProcessArguments(classpathArgumentBuilder);
 		assertEquals(convertFromWindowsClassPath(fakeJavaHomeRule.getRoot().getAbsolutePath()) + "/bin/java",
 				convertFromWindowsClassPath(get(arguments, 0)));
 	}
@@ -195,7 +198,9 @@ public class RuntimeEnvironmentTest {
 		List<String> additionalArgs = asList("-Xdebug", "-Xnoagent",
 				"-Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=y");
 		environment.addVMArgs(additionalArgs);
-		List<String> actualArgs = environment.createProcessArguments(new File("file.classpath"));
+
+		ClasspathArgumentBuilder classpathArgumentBuilder = mock(ClasspathArgumentBuilder.class);
+		List<String> actualArgs = environment.createProcessArguments(classpathArgumentBuilder);
 		assertTrue(actualArgs.toString(), actualArgs.containsAll(additionalArgs));
 	}
 

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/process/WhenCreatingRunnerProcessConnection.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/process/WhenCreatingRunnerProcessConnection.java
@@ -41,6 +41,8 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.List;
 
+import org.infinitest.environment.ClasspathArgumentBuilder;
+import org.infinitest.environment.FileClasspathArgumentBuilder;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.testrunner.CrashingTestRunner;
 import org.infinitest.testrunner.FakeRunner;
@@ -79,10 +81,11 @@ public class WhenCreatingRunnerProcessConnection {
 	private List<TestEvent> sendMessageWithServerSocket(String... messages) throws UnknownHostException, IOException, ClassNotFoundException {
 		ServerSocket serverSocket = new ServerSocket(0);
 		try {
-			
 			RuntimeEnvironment fakeEnvironment = fakeEnvironment();
-			File file = fakeEnvironment.createClasspathFile();
-			factory.startProcess(serverSocket.getLocalPort(), fakeEnvironment, file);
+			File file = fakeEnvironment.createClasspathArgumentFile();
+			
+			ClasspathArgumentBuilder classpathArgumentBuilder = new FileClasspathArgumentBuilder(file);
+			factory.startProcess(serverSocket.getLocalPort(), fakeEnvironment, classpathArgumentBuilder);
 			serverSocket.setSoTimeout(2500);
 			Socket socket = serverSocket.accept();
 			ObjectInputStream inStream = new ObjectInputStream(socket.getInputStream());


### PR DESCRIPTION
mockito-inline relies on instrumentation to mock static methods, this does not seem to be possible when the classloader is overridden because it does not implement the required methods

Pull request #260 was introduced to solve the problem when the classpath is too big to fit in the shell environment.
Since Java 9 it is possible to use argument file expanded by the java process, use this native feature instead of a custom classloader 
https://docs.oracle.com/en/java/javase/15/docs/specs/man/java.html#java-command-line-argument-files

Introduced ClasspathArgumentBuilder to the pre Java 9 case (use standard arguments) and post Java 9 (use an argument file)

Fixes #319 