### PR TITLE
deps: upgrade mockito to 4.7.0

### DIFF
--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/EclipsePluginInfinitestJarsLocatorTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/EclipsePluginInfinitestJarsLocatorTest.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.osgi.framework.Bundle;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/FailureMediatorTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/FailureMediatorTest.java
@@ -27,18 +27,22 @@
  */
 package org.infinitest.eclipse;
 
-import static com.google.common.collect.Lists.*;
-import static org.infinitest.testrunner.TestEvent.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.infinitest.testrunner.TestEvent.methodFailed;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.Collection;
 
-import org.infinitest.eclipse.markers.*;
-import org.infinitest.eclipse.workspace.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
-import org.mockito.*;
+import org.infinitest.eclipse.markers.MarkerInfo;
+import org.infinitest.eclipse.markers.ProblemMarkerInfo;
+import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
+import org.infinitest.eclipse.workspace.FakeResourceFinder;
+import org.infinitest.testrunner.TestEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class FailureMediatorTest {
 	private FailureMediator mediator;

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenCheckingForSaveEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenCheckingForSaveEvents.java
@@ -27,19 +27,28 @@
  */
 package org.infinitest.eclipse.event;
 
-import static org.eclipse.core.resources.IResourceChangeEvent.*;
-import static org.eclipse.core.resources.IResourceDelta.*;
-import static org.eclipse.core.resources.IncrementalProjectBuilder.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.eclipse.core.resources.IResourceChangeEvent.POST_CHANGE;
+import static org.eclipse.core.resources.IResourceDelta.CONTENT;
+import static org.eclipse.core.resources.IResourceDelta.MARKERS;
+import static org.eclipse.core.resources.IncrementalProjectBuilder.AUTO_BUILD;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.eclipse.core.internal.events.*;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.trim.*;
-import org.junit.*;
+import org.eclipse.core.internal.events.ResourceChangeEvent;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.infinitest.eclipse.ResourceEventSupport;
+import org.infinitest.eclipse.trim.SaveListener;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenCheckingForSaveEvents extends ResourceEventSupport {
 	private SaveDetector detector;
@@ -121,7 +130,7 @@ public class WhenCheckingForSaveEvents extends ResourceEventSupport {
 	protected IResourceDelta createSaveDelta() throws CoreException {
 		IResourceDelta javaResource = mock(IResourceDelta.class);
 		when(javaResource.getFullPath()).thenReturn(new Path("a.java"));
-		javaResource.accept((IResourceDeltaVisitor) anyObject());
+		javaResource.accept(any(IResourceDeltaVisitor.class));
 
 		return createResourceDelta(project, new IResourceDelta[] { javaResource });
 	}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenDispatchingResourceChangeEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenDispatchingResourceChangeEvents.java
@@ -50,12 +50,12 @@ public class WhenDispatchingResourceChangeEvents {
 		when(event.getDelta()).thenReturn(delta);
 
 		notifier.resourceChanged(event);
-		verifyZeroInteractions(eventQueue);
+		verifyNoInteractions(eventQueue);
 	}
 
 	@Test
 	public void shouldIgnoreEventsWithNoDelta() {
 		notifier.resourceChanged(mock(IResourceChangeEvent.class));
-		verifyZeroInteractions(eventQueue);
+		verifyNoInteractions(eventQueue);
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenNoProcessorsCanHandleEvent.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenNoProcessorsCanHandleEvent.java
@@ -39,6 +39,6 @@ public class WhenNoProcessorsCanHandleEvent {
 
 		CoreUpdateNotifier factory = new CoreUpdateNotifier(eventQueue);
 		factory.processEvent(null);
-		verifyZeroInteractions(eventQueue);
+		verifyNoInteractions(eventQueue);
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
@@ -51,7 +51,7 @@ public class WhenRespondingToBuildEvents extends ResourceEventSupport {
 
 	@After
 	public void verifyWorkspace() {
-		verifyZeroInteractions(workspace);
+		verifyNoInteractions(workspace);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToCleanEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToCleanEvents.java
@@ -63,7 +63,7 @@ public class WhenRespondingToCleanEvents extends ResourceEventSupport {
 	@Test
 	public void shouldHandleACleanBuildOnAnUnIndexedProject() throws JavaModelException {
 		processEvent(cleanBuildEvent());
-		verifyZeroInteractions(coreRegistry);
+		verifyNoInteractions(coreRegistry);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToResourceChangeEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToResourceChangeEvents.java
@@ -27,12 +27,14 @@
  */
 package org.infinitest.eclipse.event;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import org.eclipse.core.resources.*;
-import org.infinitest.*;
-import org.junit.*;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.infinitest.EventQueue;
+import org.infinitest.NamedRunnable;
+import org.junit.Test;
 
 public class WhenRespondingToResourceChangeEvents {
 	private CoreUpdateNotifier chain;

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/FakeProblemMarkerInfo.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/FakeProblemMarkerInfo.java
@@ -27,13 +27,15 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.infinitest.eclipse.workspace.*;
-import org.infinitest.testrunner.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.infinitest.eclipse.workspace.FakeResourceFinder;
+import org.infinitest.testrunner.TestEvent;
 
 final class FakeProblemMarkerInfo extends ProblemMarkerInfo {
 	public FakeProblemMarkerInfo(TestEvent event) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenPlacingMarkersInJavaClasses.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenPlacingMarkersInJavaClasses.java
@@ -27,18 +27,23 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static java.util.Arrays.*;
-import static org.infinitest.eclipse.workspace.FakeResourceFactory.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.infinitest.eclipse.workspace.FakeResourceFactory.stubResource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.Collections;
 
-import org.eclipse.core.resources.*;
-import org.infinitest.eclipse.workspace.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.eclipse.core.resources.IResource;
+import org.infinitest.eclipse.workspace.ResourceLookup;
+import org.infinitest.testrunner.PointOfFailure;
+import org.infinitest.testrunner.TestEvent;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenPlacingMarkersInJavaClasses {
 	private TestEvent event;

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -79,7 +79,7 @@ public class WhenPreferencesAreChanged {
 	public void shouldIgnoreIfPropertyNameDoesNotMatch() {
 		when(eventSource.getPreferenceName()).thenReturn("SomeEventName");
 		changeProperty(VALUE, true, false);
-		verifyZeroInteractions(controller);
+		verifyNoInteractions(controller);
 	}
 
 	@Test
@@ -100,7 +100,7 @@ public class WhenPreferencesAreChanged {
 	public void shouldIgnoreOtherPropertyTypes() {
 		when(eventSource.getPreferenceName()).thenReturn(PARALLEL_CORES);
 		changeProperty(IS_VALID, false, true);
-		verifyZeroInteractions(controller);
+		verifyNoInteractions(controller);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -27,20 +27,30 @@
  */
 package org.infinitest.eclipse.trim;
 
-import static java.util.Arrays.*;
-import static org.eclipse.swt.SWT.*;
-import static org.infinitest.CoreStatus.*;
-import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.*;
-import static org.infinitest.testrunner.TestEvent.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.eclipse.swt.SWT.COLOR_BLACK;
+import static org.eclipse.swt.SWT.COLOR_DARK_GREEN;
+import static org.eclipse.swt.SWT.COLOR_DARK_RED;
+import static org.eclipse.swt.SWT.COLOR_WHITE;
+import static org.eclipse.swt.SWT.COLOR_YELLOW;
+import static org.infinitest.CoreStatus.FAILING;
+import static org.infinitest.CoreStatus.PASSING;
+import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.runningTests;
+import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.workspaceErrors;
+import static org.infinitest.testrunner.TestEvent.methodFailed;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.Collections;
 
-import org.infinitest.*;
-import org.infinitest.eclipse.status.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.TestQueueEvent;
+import org.infinitest.eclipse.status.WorkspaceStatus;
+import org.infinitest.testrunner.TestCaseEvent;
+import org.infinitest.testrunner.TestResults;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenShowingStatusInTheStatusBar {
 	private VisualStatusPresenter presenter;

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
@@ -27,22 +27,45 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
-import static org.eclipse.core.resources.IResource.*;
-import static org.eclipse.jdt.core.IClasspathEntry.*;
-import static org.eclipse.jdt.core.IJavaModelMarker.*;
-import static org.eclipse.jdt.core.IPackageFragmentRoot.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.eclipse.core.resources.IResource.DEPTH_INFINITE;
+import static org.eclipse.jdt.core.IClasspathEntry.CPE_LIBRARY;
+import static org.eclipse.jdt.core.IClasspathEntry.CPE_PROJECT;
+import static org.eclipse.jdt.core.IClasspathEntry.CPE_SOURCE;
+import static org.eclipse.jdt.core.IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER;
+import static org.eclipse.jdt.core.IPackageFragmentRoot.K_BINARY;
+import static org.eclipse.jdt.core.IPackageFragmentRoot.K_SOURCE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.net.*;
-import java.util.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.jobs.*;
-import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.core.eval.*;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaModel;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IRegion;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.eval.IEvaluationContext;
 
 public class JavaProjectBuilder implements IJavaProject {
 	public static final String PATH_TO_WORKSPACE = "/path/to/workspace/";
@@ -157,7 +180,7 @@ public class JavaProjectBuilder implements IJavaProject {
 		if (marker != null) {
 			try {
 				when(resource.createMarker(anyString())).thenReturn(marker);
-				resource.deleteMarkers((String) anyObject(), eq(true), eq(DEPTH_INFINITE));
+				resource.deleteMarkers(anyString(), eq(true), eq(DEPTH_INFINITE));
 			} catch (CoreException e) {
 				throw new RuntimeException(e);
 			}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCompileErrorsExistInAProject.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCompileErrorsExistInAProject.java
@@ -71,7 +71,7 @@ public class WhenCompileErrorsExistInAProject extends ResourceEventSupport {
 
 		assertStatusIs(workspaceErrors());
 
-		verifyZeroInteractions(project);
+		verifyNoInteractions(project);
 	}
 
 	private void assertStatusIs(WorkspaceStatus expectedStatus) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCoresAreAddedOrRemoved.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCoresAreAddedOrRemoved.java
@@ -27,13 +27,18 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import org.infinitest.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.console.*;
-import org.junit.*;
+import org.infinitest.InfinitestCore;
+import org.infinitest.ResultCollector;
+import org.infinitest.TestQueueListener;
+import org.infinitest.eclipse.CoreLifecycleObserver;
+import org.infinitest.eclipse.SlowTestObserver;
+import org.infinitest.eclipse.console.ConsolePopulatingListener;
+import org.junit.Test;
 
 public class WhenCoresAreAddedOrRemoved {
 	private InfinitestCore core;

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
@@ -27,18 +27,22 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import org.eclipse.core.runtime.*;
-import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.launching.*;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
-import org.mockito.runners.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.launching.IRuntimeClasspathEntry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WhenResolvingClassPath {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenUpdatingTheProjectsInTheWorkspace.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenUpdatingTheProjectsInTheWorkspace.java
@@ -27,26 +27,35 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
-import static java.util.Collections.*;
-import static org.infinitest.eclipse.util.StatusMatchers.*;
-import static org.infinitest.eclipse.workspace.JavaProjectBuilder.*;
-import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
+import static org.infinitest.eclipse.util.StatusMatchers.equalsStatus;
+import static org.infinitest.eclipse.workspace.JavaProjectBuilder.project;
+import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.findingTests;
+import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.noTestsRun;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.jdt.core.*;
-import org.infinitest.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.status.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IJavaProject;
+import org.infinitest.InfinitestCore;
+import org.infinitest.eclipse.ResourceEventSupport;
+import org.infinitest.eclipse.SystemClassPathJarLocator;
+import org.infinitest.eclipse.UpdateListener;
+import org.infinitest.eclipse.status.WorkspaceStatus;
+import org.infinitest.eclipse.status.WorkspaceStatusListener;
 import org.infinitest.environment.RuntimeEnvironment;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenUpdatingTheProjectsInTheWorkspace extends ResourceEventSupport {
 	private List<ProjectFacade> projects;

--- a/infinitest-intellij/src/test/java/org/infinitest/TestInfinitestPresenter.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/TestInfinitestPresenter.java
@@ -27,23 +27,33 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-import static org.infinitest.CoreStatus.*;
-import static org.infinitest.intellij.plugin.launcher.InfinitestPresenter.*;
-import static org.infinitest.intellij.plugin.launcher.StatusMessages.*;
-import static org.infinitest.util.InfinitestUtils.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.infinitest.CoreStatus.FAILING;
+import static org.infinitest.CoreStatus.INDEXING;
+import static org.infinitest.CoreStatus.PASSING;
+import static org.infinitest.CoreStatus.SCANNING;
+import static org.infinitest.intellij.plugin.launcher.InfinitestPresenter.FAILING_COLOR;
+import static org.infinitest.intellij.plugin.launcher.InfinitestPresenter.PASSING_COLOR;
+import static org.infinitest.intellij.plugin.launcher.InfinitestPresenter.UNKNOWN_COLOR;
+import static org.infinitest.intellij.plugin.launcher.StatusMessages.getMessage;
+import static org.infinitest.util.InfinitestUtils.formatTime;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.List;
 
-import javax.swing.*;
+import javax.swing.Action;
 
-import org.infinitest.intellij.*;
-import org.infinitest.intellij.plugin.launcher.*;
-import org.infinitest.intellij.plugin.swingui.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.intellij.FakeInfinitestAnnotator;
+import org.infinitest.intellij.plugin.launcher.InfinitestPresenter;
+import org.infinitest.intellij.plugin.swingui.InfinitestView;
+import org.infinitest.testrunner.TestResultsListener;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TestInfinitestPresenter {
 	private InfinitestView mockView;

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenCompilationCompletes.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenCompilationCompletes.java
@@ -27,15 +27,18 @@
  */
 package org.infinitest.intellij;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
-import org.infinitest.*;
+import org.infinitest.InfinitestCore;
 import org.infinitest.environment.RuntimeEnvironment;
-import org.infinitest.intellij.idea.*;
-import org.junit.*;
-import org.mockito.*;
+import org.infinitest.intellij.idea.IdeaCompilationListener;
+import org.junit.Before;
+import org.junit.Test;
 
-import com.intellij.openapi.compiler.*;
+import com.intellij.openapi.compiler.CompilationStatusListener;
 
 public class WhenCompilationCompletes {
 	private final ModuleSettings moduleSettings = new FakeModuleSettings("test");
@@ -51,7 +54,7 @@ public class WhenCompilationCompletes {
 		CompilationStatusListener listener = new IdeaCompilationListener(core, moduleSettings);
 		listener.compilationFinished(false, 0, 0, null);
 
-		verify(core).setRuntimeEnvironment(Matchers.any(RuntimeEnvironment.class));
+		verify(core).setRuntimeEnvironment(any(RuntimeEnvironment.class));
 		verify(core).update();
 	}
 
@@ -60,7 +63,7 @@ public class WhenCompilationCompletes {
 		CompilationStatusListener listener = new IdeaCompilationListener(core, moduleSettings);
 		listener.compilationFinished(true, 0, 0, null);
 
-		verify(core, never()).setRuntimeEnvironment(Matchers.any(RuntimeEnvironment.class));
+		verify(core, never()).setRuntimeEnvironment(any(RuntimeEnvironment.class));
 		verify(core, never()).update();
 	}
 
@@ -69,7 +72,7 @@ public class WhenCompilationCompletes {
 		CompilationStatusListener listener = new IdeaCompilationListener(core, moduleSettings);
 		listener.compilationFinished(false, 1, 0, null);
 
-		verify(core, never()).setRuntimeEnvironment(Matchers.any(RuntimeEnvironment.class));
+		verify(core, never()).setRuntimeEnvironment(any(RuntimeEnvironment.class));
 		verify(core, never()).update();
 	}
 }

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLaunchingInfinitest.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLaunchingInfinitest.java
@@ -27,17 +27,20 @@
  */
 package org.infinitest.intellij;
 
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import javax.swing.*;
+import javax.swing.JPanel;
 
-import org.infinitest.intellij.plugin.launcher.*;
-import org.junit.*;
-import org.mockito.*;
+import org.infinitest.intellij.plugin.launcher.InfinitestLauncher;
+import org.infinitest.intellij.plugin.launcher.InfinitestLauncherImpl;
+import org.junit.Before;
+import org.junit.Test;
 
-import com.intellij.openapi.fileEditor.*;
-import com.intellij.openapi.wm.*;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.wm.ToolWindowManager;
 
 public class WhenLaunchingInfinitest {
 	private ModuleSettings moduleSettings;
@@ -56,6 +59,6 @@ public class WhenLaunchingInfinitest {
 		InfinitestLauncher launcher = new InfinitestLauncherImpl(moduleSettings, registry, new FakeCompilationNotifier(), new FakeSourceNavigator(), fileEditorManagerMock, toolWindowManagerMock);
 		launcher.launchInfinitest();
 
-		verify(registry).registerToolWindow(Matchers.any(JPanel.class), eq("foo"));
+		verify(registry).registerToolWindow(any(JPanel.class), eq("foo"));
 	}
 }

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLoggingError.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLoggingError.java
@@ -27,11 +27,12 @@
  */
 package org.infinitest.intellij;
 
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import org.infinitest.intellij.plugin.swingui.*;
-import org.junit.*;
+import org.infinitest.intellij.plugin.swingui.InfinitestView;
+import org.junit.Test;
 
 public class WhenLoggingError {
 	private static final Exception ERROR = new Exception("test");

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLoggingMessage.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/WhenLoggingMessage.java
@@ -27,13 +27,17 @@
  */
 package org.infinitest.intellij;
 
-import static java.util.logging.Level.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import org.infinitest.intellij.plugin.swingui.*;
-import org.infinitest.util.*;
-import org.junit.*;
+import org.infinitest.intellij.plugin.swingui.InfinitestView;
+import org.infinitest.util.LoggingListener;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenLoggingMessage {
 	private LoggingListener listener;

--- a/infinitest-lib/src/test/java/org/infinitest/WhenATestIsRun.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenATestIsRun.java
@@ -27,14 +27,16 @@
  */
 package org.infinitest;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.Comparator;
 
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.testrunner.TestResultsListener;
+import org.infinitest.testrunner.TestRunner;
+import org.junit.Test;
 
 public class WhenATestIsRun {
 	@Test

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTestsAreDisabled.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTestsAreDisabled.java
@@ -27,21 +27,25 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Sets.*;
-import static org.infinitest.CoreDependencySupport.*;
-import static org.infinitest.util.InfinitestUtils.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.infinitest.CoreDependencySupport.withChangedFiles;
+import static org.infinitest.util.InfinitestUtils.setify;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 
-import org.infinitest.parser.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.parser.JavaClass;
+import org.infinitest.parser.TestDetector;
+import org.infinitest.testrunner.TestRunner;
+import org.junit.Test;
 
-import com.fakeco.fakeproduct.simple.*;
+import com.fakeco.fakeproduct.simple.PassingTest;
 
 public class WhenTestsAreDisabled {
 	@SuppressWarnings("unchecked")

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTestsResultsAreProcessed.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTestsResultsAreProcessed.java
@@ -27,21 +27,26 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Iterables.*;
-import static java.util.Arrays.*;
-import static org.infinitest.CoreStatus.*;
-import static org.infinitest.testrunner.TestEvent.*;
-import static org.infinitest.util.InfinitestTestUtils.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Arrays.asList;
+import static org.infinitest.CoreStatus.PASSING;
+import static org.infinitest.CoreStatus.RUNNING;
+import static org.infinitest.CoreStatus.SCANNING;
+import static org.infinitest.testrunner.TestEvent.methodFailed;
+import static org.infinitest.util.InfinitestTestUtils.emptyStringList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.Collection;
 
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.testrunner.TestEvent;
+import org.junit.Before;
+import org.junit.Test;
 
-import com.google.common.collect.*;
+import com.google.common.collect.Lists;
 
 public class WhenTestsResultsAreProcessed extends ResultCollectorTestSupport {
 	private EventSupport statusListener;

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTheRuntimeEnvironmentChanges.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTheRuntimeEnvironmentChanges.java
@@ -27,19 +27,24 @@
  */
 package org.infinitest;
 
-import static org.infinitest.CoreDependencySupport.*;
-import static org.infinitest.environment.FakeEnvironments.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.infinitest.CoreDependencySupport.createCore;
+import static org.infinitest.CoreDependencySupport.withNoChangedFiles;
+import static org.infinitest.CoreDependencySupport.withNoTestsToRun;
+import static org.infinitest.environment.FakeEnvironments.emptyRuntimeEnvironment;
+import static org.infinitest.environment.FakeEnvironments.fakeEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.Comparator;
 
-import org.infinitest.changedetect.*;
+import org.infinitest.changedetect.ChangeDetector;
 import org.infinitest.environment.RuntimeEnvironment;
-import org.infinitest.parser.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.parser.TestDetector;
+import org.infinitest.testrunner.TestResultsListener;
+import org.infinitest.testrunner.TestRunner;
+import org.junit.Test;
 
 public class WhenTheRuntimeEnvironmentChanges {
 	@Test

--- a/infinitest-lib/src/test/java/org/infinitest/WhenWatchingMultipleCores.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenWatchingMultipleCores.java
@@ -27,15 +27,21 @@
  */
 package org.infinitest;
 
-import static org.infinitest.testrunner.TestEvent.TestState.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import junit.framework.*;
+import static org.infinitest.testrunner.TestEvent.TestState.METHOD_FAILURE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.testrunner.TestCaseEvent;
+import org.infinitest.testrunner.TestEvent;
+import org.infinitest.testrunner.TestResults;
+import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.AssertionFailedError;
 
 public class WhenWatchingMultipleCores {
 	private static final String TEST_NAME = "com.fakeco.TestFoo";

--- a/infinitest-lib/src/test/java/org/infinitest/plugin/WhenRunningTests.java
+++ b/infinitest-lib/src/test/java/org/infinitest/plugin/WhenRunningTests.java
@@ -27,19 +27,28 @@
  */
 package org.infinitest.plugin;
 
-import static org.infinitest.CoreStatus.*;
-import static org.infinitest.environment.FakeEnvironments.*;
-import static org.junit.Assert.*;
+import static org.infinitest.CoreStatus.FAILING;
+import static org.infinitest.environment.FakeEnvironments.fakeEnvironment;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalMatchers.not;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.infinitest.*;
-import org.infinitest.filter.*;
-import org.infinitest.parser.*;
-import org.junit.*;
-import org.mockito.*;
+import org.infinitest.ConcurrencyController;
+import org.infinitest.EventSupport;
+import org.infinitest.FakeEventQueue;
+import org.infinitest.InfinitestCore;
+import org.infinitest.InfinitestCoreBuilder;
+import org.infinitest.ResultCollector;
+import org.infinitest.filter.TestFilter;
+import org.infinitest.parser.JavaClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 
-import com.fakeco.fakeproduct.simple.*;
+import com.fakeco.fakeproduct.simple.FailingTest;
+import com.fakeco.fakeproduct.simple.PassingTest;
 
 public class WhenRunningTests {
   private static EventSupport eventHistory;
@@ -89,8 +98,8 @@ public class WhenRunningTests {
   static ArgumentMatcher<JavaClass> startsWith(final String namePrefix) {
     return new ArgumentMatcher<JavaClass>() {
       @Override
-      public boolean matches(Object argument) {
-        return (argument instanceof JavaClass) && ((JavaClass) argument).getName().startsWith(namePrefix);
+      public boolean matches(JavaClass argument) {
+        return argument.getName().startsWith(namePrefix);
       }
     };
   }

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/ResultProcessorTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/ResultProcessorTest.java
@@ -27,17 +27,23 @@
  */
 package org.infinitest.testrunner;
 
-import static org.infinitest.testrunner.TestEvent.TestState.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.infinitest.testrunner.TestEvent.TestState.TEST_CASE_STARTING;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
+import java.io.IOException;
 
-import org.infinitest.*;
+import org.infinitest.EventSupport;
 import org.infinitest.environment.RuntimeEnvironment;
-import org.infinitest.testrunner.process.*;
-import org.junit.*;
+import org.infinitest.testrunner.process.ProcessConnection;
+import org.infinitest.testrunner.process.ProcessConnectionFactory;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ResultProcessorTest {
 	private TestQueueProcessor reader;
@@ -84,7 +90,7 @@ public class ResultProcessorTest {
 		reader.close();
 		eventAssert.assertRunComplete();
 
-		verify(factory, times(1)).getConnection(any(RuntimeEnvironment.class), any(OutputStreamHandler.class));
+		verify(factory, times(1)).getConnection(isNull(), any(OutputStreamHandler.class));
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
-		<mockito.version>1.10.8</mockito.version>
+		<mockito.version>4.7.0</mockito.version>
 		<junit.version>4.12</junit.version>
 		<junit5.version>5.0.3</junit5.version>
 		<junit5-platform.version>1.0.3</junit5-platform.version>


### PR DESCRIPTION
Mocking abstract classes fails with mockito 1.10.8 and java >= 16 since it uses the unmaintained CGLIB