### PR TITLE
deps: upgrade surefire to 3.0.0-M7

### DIFF
--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenResolvingClassPath.java
@@ -105,11 +105,6 @@ public class WhenResolvingClassPath {
 		when(eclipseFacade.computeDefaultRuntimeClassPath(project)).thenReturn(new String[0]);
 		when(eclipseFacade.computeUnresolvedRuntimeClasspath(project)).thenReturn(new IRuntimeClasspathEntry[]{runtimeClasspathEntry});
 		when(runtimeClasspathEntry.getVariableName()).thenReturn("org.eclipse.jdt.launching.JRE_CONTAINER");
-		when(runtimeClasspathEntry.getPath()).thenReturn(path);
-		when(eclipseFacade.getClasspathContainer(path, project)).thenReturn(classpathContainer);
-		when(classpathContainer.getClasspathEntries()).thenReturn(new IClasspathEntry[]{classpathEntry});
-		when(classpathEntry.getPath()).thenReturn(jarPath);
-		when(jarPath.toString()).thenReturn("3.jar");
 
 		String classpath = classPathResolver.rawClasspath(project);
 
@@ -121,11 +116,6 @@ public class WhenResolvingClassPath {
 		when(eclipseFacade.computeDefaultRuntimeClassPath(project)).thenReturn(new String[0]);
 		when(eclipseFacade.computeUnresolvedRuntimeClasspath(project)).thenReturn(new IRuntimeClasspathEntry[]{runtimeClasspathEntry});
 		when(runtimeClasspathEntry.getVariableName()).thenReturn("SCALA_CONTAINER");
-		when(runtimeClasspathEntry.getPath()).thenReturn(path);
-		when(eclipseFacade.getClasspathContainer(path, project)).thenReturn(classpathContainer);
-		when(classpathContainer.getClasspathEntries()).thenReturn(new IClasspathEntry[]{classpathEntry});
-		when(classpathEntry.getPath()).thenReturn(jarPath);
-		when(jarPath.toString()).thenReturn("3.zip");
 
 		String classpath = classPathResolver.rawClasspath(project);
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		<assertj.version>3.11.1</assertj.version>
 		<autovalue.version>1.3</autovalue.version>
 		<jcommander.version>1.35</jcommander.version>
+		<surefire.version>3.0.0-M7</surefire.version>
 	</properties>
 
 	<profiles>
@@ -165,7 +166,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.12.4</version>
+					<version>${surefire.version}</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-deploy-plugin</artifactId>
@@ -223,7 +224,7 @@
 					<dependency>
 						<groupId>org.apache.maven.surefire</groupId>
 						<artifactId>surefire-junit47</artifactId>
-						<version>2.12.4</version>
+						<version>${surefire.version}</version>
 					</dependency>
 				</dependencies>
 				<configuration>


### PR DESCRIPTION
- upgrade surefire to 3.0.0-M7
- surefire now reports unused mockito stubbings and fails the build, remove unused stubbings in WhenResolvingClassPath