### PR TITLE
fix: jdk modules should be excluded when building the classpath

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -49,6 +49,7 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.CompilerModuleExtension;
+import com.intellij.openapi.roots.JdkOrderEntry;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
@@ -182,7 +183,7 @@ public class IdeaModuleSettings implements ModuleSettings {
 				 */
 				LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry) entry;
 				files.addAll(Arrays.asList(libraryOrderEntry.getRootFiles(OrderRootType.CLASSES)));
-			} else {
+			} else if (!(entry instanceof JdkOrderEntry)) {
 				/*
 				 * all other cases (whichever they are) we want to have their
 				 * classes outputs.

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.intellij.idea;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.IsEqual.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -84,7 +83,7 @@ public class WhenBuildingIdeaModuleClassPath {
 		final List<File> classPathElementsList = ideaModuleSettingsSpy.listClasspathElements();
 		
 		verifyNoInteractions(jdkOrderEntry);
-		assertThat(classPathElementsList).hasSize(1);
+		assertThat(classPathElementsList.size(), equalTo(1));
 	}
 
 	private static OrderEntry orderEntry() {

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
@@ -27,6 +27,7 @@
  */
 package org.infinitest.intellij.idea;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.IsEqual.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -69,6 +70,21 @@ public class WhenBuildingIdeaModuleClassPath {
 		assertThat(classPathElementsList.get(2).getPath(), equalTo(PATH_C));
 		assertThat(classPathElementsList.get(3).getPath(), equalTo(PATH_D));
 		assertThat(classPathElementsList.size(), equalTo(4));
+	}
+	
+	@Test
+	public void shouldExcludeJdkModules() {
+		OrderEntry jdkOrderEntry = mock(JdkOrderEntry.class);
+		doReturn(new OrderEntry[] { jdkOrderEntry }).when(moduleRootManagerMock).getOrderEntries();
+		doReturn(new VirtualFile[] { fileWith(PATH_D) }).when(compilerModuleExtension).getOutputRoots(true);
+		doReturn(new VirtualFile[] { fileWith(PATH_C) }).when(jdkOrderEntry).getFiles(OrderRootType.CLASSES);
+		doReturn(moduleRootManagerMock).when(ideaModuleSettingsSpy).moduleRootManagerInstance();
+		doReturn(compilerModuleExtension).when(ideaModuleSettingsSpy).compilerModuleExtension();
+		
+		final List<File> classPathElementsList = ideaModuleSettingsSpy.listClasspathElements();
+		
+		verifyNoInteractions(jdkOrderEntry);
+		assertThat(classPathElementsList).hasSize(1);
 	}
 
 	private static OrderEntry orderEntry() {


### PR DESCRIPTION
The intellij log is cluttered by messages about modules