### PR TITLE
fix: search the point of failure in the 'all' scope

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaSourceNavigator.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaSourceNavigator.java
@@ -61,7 +61,7 @@ public class IdeaSourceNavigator implements SourceNavigator {
 
 	@Nullable
 	private VirtualFile fileForClass() {
-		PsiClass clazz = JavaPsiFacade.getInstance(project).findClass(className, projectScope(project));
+		PsiClass clazz = JavaPsiFacade.getInstance(project).findClass(className, allScope(project));
 		if ((clazz != null) && (clazz.getContainingFile() != null)) {
 			return clazz.getContainingFile().getVirtualFile();
 		}

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestLineMarkersPass.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestLineMarkersPass.java
@@ -72,6 +72,13 @@ public class InfinitestLineMarkersPass extends TextEditorHighlightingPass implem
 			String name = psiClass.getQualifiedName();
 			if ((name != null) && name.equals(each.getPointOfFailureClassName())) {
 				int line = each.getPointOfFailureLineNumber() - 1;
+				
+				// Since the failure might be a in a dependency and the sources might be unavailable
+				// we might be showing a decompiled .class file with different line numbers, so
+				// we need to adjust the line number of the point of failure
+				line = Math.max(line, 0);
+				line = Math.min(line, document.getLineCount() - 1);
+				
 				RangeHighlighter rangeHighlighter = model.addLineHighlighter(line, FIRST, null);
 				rangeHighlighter.setGutterIconRenderer(new InfinitestGutterIconRenderer(each));
 				rangeHighlighter.putUserData(KEY, each);


### PR DESCRIPTION
The test might fail to initialize in a class from a library as it was the case for #319. Search in the 'all' scope (including libraries) for the point of failure. Since we might land in a decompiled class the line number might be outside of the range for the decompiled source, so we need to adjust it or we get an exception in the highlighter pass

Fixes #253 