### PR TITLE
Eclipse plugin performance improvements

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestActivationController.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestActivationController.java
@@ -84,6 +84,8 @@ public class InfinitestActivationController implements PluginActivationControlle
 
 	private void attachListener() {
 		pluginEnabled = true;
+		// calling addResourceChangeListener() without the event type second argument is equivalent to
+		// listening only to: PRE_CLOSE, PRE_DELETE and POST_CHANGE
 		workspace.addResourceChangeListener(updateNotifier, IResourceChangeEvent.POST_BUILD);
 	}
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestActivationController.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestActivationController.java
@@ -84,7 +84,7 @@ public class InfinitestActivationController implements PluginActivationControlle
 
 	private void attachListener() {
 		pluginEnabled = true;
-		workspace.addResourceChangeListener(updateNotifier);
+		workspace.addResourceChangeListener(updateNotifier, IResourceChangeEvent.POST_BUILD);
 	}
 
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/ClassFileChangeProcessor.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/ClassFileChangeProcessor.java
@@ -28,7 +28,6 @@
 package org.infinitest.eclipse.event;
 
 import static org.eclipse.core.resources.IResourceChangeEvent.POST_BUILD;
-import static org.eclipse.core.resources.IResourceChangeEvent.POST_CHANGE;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -54,7 +53,7 @@ class ClassFileChangeProcessor extends EclipseEventProcessor {
 
 	@Override
 	public boolean canProcessEvent(IResourceChangeEvent event) {
-		return (event.getType() & (POST_BUILD | POST_CHANGE)) > 0;
+		return (event.getType() & POST_BUILD) > 0;
 	}
 
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/ClassFileChangeProcessor.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/ClassFileChangeProcessor.java
@@ -80,8 +80,8 @@ class ClassFileChangeProcessor extends EclipseEventProcessor {
 	
 	public static class ClassFileChangeProcessorVisitor implements IResourceDeltaVisitor {
 
-		private Set<IResource> modifiedResources = new HashSet<IResource>();
-		private Set<IResource> removedResources = new HashSet<IResource>();
+		private Set<IResource> modifiedResources = new HashSet<>();
+		private Set<IResource> removedResources = new HashSet<>();
 		
 		@Override
 		public boolean visit(IResourceDelta d) throws CoreException {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
@@ -51,6 +51,7 @@ import org.infinitest.eclipse.UpdateListener;
 import org.infinitest.eclipse.status.WorkspaceStatus;
 import org.infinitest.eclipse.status.WorkspaceStatusListener;
 import org.infinitest.environment.RuntimeEnvironment;
+import org.infinitest.parser.JavaClass;
 import org.infinitest.util.Events;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -96,14 +97,15 @@ class EclipseWorkspace implements WorkspaceFacade {
 	@Override
 	public void remove(Set<IResource> removedResources) {
 		Map<ProjectFacade, Set<File>> removedFilesByProject = groupResourcesByProject(removedResources);
-		
+		Set<JavaClass> removedClasses = new HashSet<JavaClass>();
+
 		for (Map.Entry<ProjectFacade, Set<File>> entry : removedFilesByProject.entrySet()) {
 			ProjectFacade project = entry.getKey();
 			Set<File> removedFiles = entry.getValue();
 			
 			InfinitestCore core = coreRegistry.getCore(project.getLocationURI());
 			if (core != null) {
-				core.remove(removedFiles);
+				core.remove(removedFiles, removedClasses);
 			}
 		}
 	}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.findingTests;
 import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.noTestsRun;
 import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.workspaceErrors;
@@ -35,9 +34,16 @@ import static org.infinitest.util.Events.eventFor;
 import static org.infinitest.util.InfinitestUtils.log;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.infinitest.InfinitestCore;
 import org.infinitest.eclipse.InfinitestJarsLocator;
@@ -54,7 +60,7 @@ class EclipseWorkspace implements WorkspaceFacade {
 	private final CoreRegistry coreRegistry;
 	private final CoreFactory coreFactory;
 	private WorkspaceStatus status;
-	private final List<WorkspaceStatusListener> statusListeners = newArrayList();
+	private final List<WorkspaceStatusListener> statusListeners = new ArrayList<>();
 	private final Events<UpdateListener> updateEvent = eventFor(UpdateListener.class);
 	private final ProjectSet projectSet;
 	private final InfinitestJarsLocator infinitestJarsClasspathProvider;
@@ -76,13 +82,28 @@ class EclipseWorkspace implements WorkspaceFacade {
 	}
 
 	@Override
-	public void updateProjects() throws CoreException {
+	public void updateProjects(Set<IResource> modifiedResources) throws CoreException {
 		if (projectSet.hasErrors()) {
 			setStatus(workspaceErrors());
 		} else {
-			int numberOfTestsToRun = updateProjectsIn(projectSet);
+			int numberOfTestsToRun = updateProjectsIn(modifiedResources);
 			if (numberOfTestsToRun == 0) {
 				setStatus(noTestsRun());
+			}
+		}
+	}
+	
+	@Override
+	public void remove(Set<IResource> removedResources) {
+		Map<ProjectFacade, Set<File>> removedFilesByProject = groupResourcesByProject(removedResources);
+		
+		for (Map.Entry<ProjectFacade, Set<File>> entry : removedFilesByProject.entrySet()) {
+			ProjectFacade project = entry.getKey();
+			Set<File> removedFiles = entry.getValue();
+			
+			InfinitestCore core = coreRegistry.getCore(project.getLocationURI());
+			if (core != null) {
+				core.remove(removedFiles);
 			}
 		}
 	}
@@ -98,27 +119,34 @@ class EclipseWorkspace implements WorkspaceFacade {
 		return status;
 	}
 
-	private int updateProjectsIn(ProjectSet projectSet) throws CoreException {
+	private int updateProjectsIn(Set<IResource> modifiedResources) throws CoreException {
 		updateEvent.fire();
 		int totalTests = 0;
+		int processedProjects = 0;
 		
-		List<ProjectFacade> projects = projectSet.projects();
-		for (int i = 0; i < projects.size(); i++) {
-			ProjectFacade project = projects.get(i);
-			setStatus(findingTests(i, projects.size(), totalTests));
-			totalTests += updateProject(project);
+		Map<ProjectFacade, Set<File>> modifiedFilesByProject = groupResourcesByProject(modifiedResources);
+		
+		for (Map.Entry<ProjectFacade, Set<File>> entry : modifiedFilesByProject.entrySet()) {
+			ProjectFacade project = entry.getKey();
+			Set<File> modifiedFiles = entry.getValue();
+			
+			setStatus(findingTests(processedProjects, modifiedFilesByProject.size(), totalTests));
+			totalTests += updateProject(project, modifiedFiles);
+			
+			processedProjects++;
 		}
+		
 		return totalTests;
 	}
 
-	private int updateProject(ProjectFacade project) throws CoreException {
+	private int updateProject(ProjectFacade project, Collection<File> changedFiles) throws CoreException {
 		RuntimeEnvironment environment = buildRuntimeEnvironment(project);
 		InfinitestCore core = coreRegistry.getCore(project.getLocationURI());
 		if (core == null) {
 			core = createCore(project, environment);
 		}
 		core.setRuntimeEnvironment(environment);
-		return core.update();
+		return core.update(changedFiles);
 	}
 
 	public RuntimeEnvironment buildRuntimeEnvironment(ProjectFacade project) throws CoreException {
@@ -145,5 +173,26 @@ class EclipseWorkspace implements WorkspaceFacade {
 		for (UpdateListener each : updateListeners) {
 			updateEvent.addListener(each);
 		}
+	}
+	
+	private Map<ProjectFacade, Set<File>> groupResourcesByProject(Set<IResource> resources) {
+		Map<ProjectFacade, Set<File>> filesByProjectFacade = new HashMap<>();
+		List<ProjectFacade> projects = projectSet.projects();
+		
+		for (IResource resource : resources) {
+			File file = null;
+			
+			for (ProjectFacade project : projects) {
+				if (project.isOnClasspath(resource)) {
+					if (file == null) {
+						file = resource.getRawLocation().makeAbsolute().toFile();
+					}
+					
+					filesByProjectFacade.computeIfAbsent(project, x -> new HashSet<File>()).add(file);
+				}
+			}
+		}
+		
+		return filesByProjectFacade;
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
@@ -169,7 +169,11 @@ class ProjectFacade implements EclipseProject {
 		}
 	}
 
+	/**
+	 * @return <code>true</code> if this class is on the project's classpath or part of the project
+	 */
 	public boolean isOnClasspath(IResource resource) {
-		return project.isOnClasspath(resource);
+		// isOnClasspath() does not seem to return true for a class in its own project
+		return project.isOnClasspath(resource) || resource.getProject().equals(project.getProject());
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
@@ -37,6 +37,7 @@ import static org.infinitest.util.InfinitestUtils.*;
 import java.io.*;
 import java.net.*;
 
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.launching.*;
@@ -166,5 +167,9 @@ class ProjectFacade implements EclipseProject {
 		} catch (JavaModelException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public boolean isOnClasspath(IResource resource) {
+		return project.isOnClasspath(resource);
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceFacade.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceFacade.java
@@ -27,8 +27,13 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import org.eclipse.core.runtime.*;
+import java.util.Set;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 
 public interface WorkspaceFacade {
-	void updateProjects() throws CoreException;
+	void updateProjects(Set<IResource> modifiedResources) throws CoreException;
+	
+	void remove(Set<IResource> removedResources);
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenActivatingThePlugin.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenActivatingThePlugin.java
@@ -63,7 +63,7 @@ public class WhenActivatingThePlugin {
 		controller.enable();
 		controller.enable();
 
-		verify(workspace).addResourceChangeListener(coreUpdateNotifier);
+		verify(workspace).addResourceChangeListener(coreUpdateNotifier, IResourceChangeEvent.POST_BUILD);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
@@ -27,17 +27,32 @@
  */
 package org.infinitest.eclipse.event;
 
-import static org.eclipse.core.resources.IResourceChangeEvent.*;
-import static org.eclipse.core.resources.IncrementalProjectBuilder.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.eclipse.core.resources.IResourceChangeEvent.POST_BUILD;
+import static org.eclipse.core.resources.IResourceChangeEvent.POST_CHANGE;
+import static org.eclipse.core.resources.IResourceChangeEvent.PRE_BUILD;
+import static org.eclipse.core.resources.IncrementalProjectBuilder.AUTO_BUILD;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-import org.eclipse.core.internal.events.*;
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.workspace.*;
-import org.junit.*;
+import org.eclipse.core.internal.events.ResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.infinitest.eclipse.ResourceEventSupport;
+import org.infinitest.eclipse.workspace.WorkspaceFacade;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenRespondingToBuildEvents extends ResourceEventSupport {
 	private ClassFileChangeProcessor processor;
@@ -49,31 +64,57 @@ public class WhenRespondingToBuildEvents extends ResourceEventSupport {
 		processor = new ClassFileChangeProcessor(workspace);
 	}
 
-	@After
-	public void verifyWorkspace() {
-		verifyNoInteractions(workspace);
-	}
-
 	@Test
 	public void shouldNotRespondToPreBuildEvents() {
 		IResourceChangeEvent event = new ResourceChangeEvent(this, PRE_BUILD, AUTO_BUILD, null);
 		assertFalse(processor.canProcessEvent(event));
+
+		verifyNoInteractions(workspace);		
 	}
 
 	@Test
 	public void shouldNotUpdateIfClassesAreNotChanged() throws CoreException {
 		processor.processEvent(emptyEvent());
+
+		verifyNoInteractions(workspace);
 	}
 
 	@Test
 	public void shouldRespondToPostBuildEvents() {
 		IResourceChangeEvent event = new ResourceChangeEvent(this, POST_BUILD, AUTO_BUILD, null);
 		assertTrue(processor.canProcessEvent(event));
+
+		verifyNoInteractions(workspace);
 	}
 
 	@Test
 	public void shouldRespondToPostChangeEvents() {
 		IResourceChangeEvent event = new ResourceChangeEvent(this, POST_CHANGE, AUTO_BUILD, null);
 		assertTrue(processor.canProcessEvent(event));
+
+		verifyNoInteractions(workspace);
+	}
+	
+	@Test
+	public void shouldHandleRemovedTestClasses() throws CoreException {
+		IResourceDelta delta = mock(IResourceDelta.class);
+		IPath path = mock(IPath.class);
+		
+		when(delta.getKind()).thenReturn(IResourceDelta.REMOVED);
+		when(delta.getAffectedChildren()).thenReturn(new IResourceDelta[] {delta});
+		doAnswer(i -> {
+			IResourceDeltaVisitor v = i.getArgument(0, IResourceDeltaVisitor.class);
+			v.visit(delta);
+			
+			return null;
+		}).when(delta).accept(any());
+		when(delta.getFullPath()).thenReturn(path);
+		when(path.toPortableString()).thenReturn("/target/test.class");
+		
+		IResourceChangeEvent event = new ResourceChangeEvent(this, PRE_BUILD, AUTO_BUILD, delta);
+		
+		processor.processEvent(event);
+		
+		verify(workspace, times(1)).remove(anySet());
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/WhenRespondingToBuildEvents.java
@@ -50,7 +50,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.infinitest.eclipse.ResourceEventSupport;
 import org.infinitest.eclipse.workspace.WorkspaceFacade;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,9 +87,10 @@ public class WhenRespondingToBuildEvents extends ResourceEventSupport {
 	}
 
 	@Test
-	public void shouldRespondToPostChangeEvents() {
+	public void shouldNotRespondToPostChangeEvents() {
+		// Not sure why we wanted to respond to change events, seems better to respond to the post build event, once the build is finished
 		IResourceChangeEvent event = new ResourceChangeEvent(this, POST_CHANGE, AUTO_BUILD, null);
-		assertTrue(processor.canProcessEvent(event));
+		assertFalse(processor.canProcessEvent(event));
 
 		verifyNoInteractions(workspace);
 	}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
@@ -385,7 +385,7 @@ public class JavaProjectBuilder implements IJavaProject {
 
 	@Override
 	public boolean isOnClasspath(IResource iResource) {
-		throw new UnsupportedOperationException();
+		return true;
 	}
 
 	@Override

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCompileErrorsExistInAProject.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenCompileErrorsExistInAProject.java
@@ -27,19 +27,24 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
-import static org.infinitest.eclipse.util.StatusMatchers.*;
-import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.infinitest.eclipse.util.StatusMatchers.equalsStatus;
+import static org.infinitest.eclipse.workspace.WorkspaceStatusFactory.workspaceErrors;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import org.eclipse.core.runtime.*;
-import org.eclipse.jdt.core.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.status.*;
-import org.junit.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IJavaProject;
+import org.infinitest.eclipse.ResourceEventSupport;
+import org.infinitest.eclipse.SystemClassPathJarLocator;
+import org.infinitest.eclipse.status.WorkspaceStatus;
+import org.junit.Before;
+import org.junit.Test;
 
 // DEBT Duplication with WhenUpdatingTheProjectsInTheWorkspace
 public class WhenCompileErrorsExistInAProject extends ResourceEventSupport {
@@ -50,7 +55,7 @@ public class WhenCompileErrorsExistInAProject extends ResourceEventSupport {
 
 	@Before
 	public void inContext() throws CoreException {
-		projects = newArrayList();
+		projects = new ArrayList<>();
 		projectSet = mock(ProjectSet.class);
 		projects.add(new ProjectFacade(project));
 		coreRegistry = mock(CoreRegistry.class);
@@ -67,7 +72,7 @@ public class WhenCompileErrorsExistInAProject extends ResourceEventSupport {
 		projects.clear();
 		projects.add(new ProjectFacade(project));
 
-		workspace.updateProjects();
+		workspace.updateProjects(Collections.emptySet());
 
 		assertStatusIs(workspaceErrors());
 

--- a/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
@@ -55,6 +55,10 @@ class DefaultInfinitestCore implements InfinitestCore {
 	private final List<ReloadListener> reloadListeners;
 	private final List<DisabledTestListener> disabledTestListeners;
 	private final RunStatistics stats;
+	/**
+	 * For the first run we need to run every test (and index every class), not just the modified classes
+	 */
+	private boolean firstRunSinceReload = true;
 
 	DefaultInfinitestCore(TestRunner testRunner, EventQueue eventQueue) {
 		normalizer = new EventNormalizer(eventQueue);
@@ -79,9 +83,21 @@ class DefaultInfinitestCore implements InfinitestCore {
 	@Override
 	public synchronized int update(Collection<File> changedFiles) {
 		log(CONFIG, "Core Update " + name);
-		int testsRun = runOptimizedTestSet(changedFiles);
-		caughtExceptions.clear();
-		return testsRun;
+		if (firstRunSinceReload) {
+			firstRunSinceReload = false;
+			return update();
+		} else {
+			int testsRun = runOptimizedTestSet(changedFiles);
+			caughtExceptions.clear();
+			return testsRun;
+		}
+	}
+	
+	@Override
+	public void remove(Collection<File> removedFiles) {
+		Set<JavaClass> removedClasses = testDetector.removeClasses(removedFiles);
+		
+		fireDisabledTestEvents(classesToNames(removedClasses));
 	}
 
 	// If this returned the number of tests that were scheduled to be run, we
@@ -89,7 +105,11 @@ class DefaultInfinitestCore implements InfinitestCore {
 	@Override
 	public synchronized int update() {
 		try {
-			return update(findChangedClassFiles());
+			boolean lookForRemovedFiles = !firstRunSinceReload;
+			firstRunSinceReload = false;
+			int testsRun = runOptimizedTestSet(findChangedClassFiles(lookForRemovedFiles));
+			caughtExceptions.clear();
+			return testsRun;
 		} catch (IOException e) {
 			checkForFatalError(e);
 		}
@@ -101,7 +121,8 @@ class DefaultInfinitestCore implements InfinitestCore {
 		log("Reloading core " + name);
 		testDetector.clear();
 		changeDetector.clear();
-
+		firstRunSinceReload = true;
+		
 		fireReload();
 	}
 
@@ -116,7 +137,7 @@ class DefaultInfinitestCore implements InfinitestCore {
 		}
 	}
 
-	private int runOptimizedTestSet(Collection<File> changedFiles) {
+	protected int runOptimizedTestSet(Collection<File> changedFiles) {
 		Set<String> oldTests = testDetector.getCurrentTests();
 		Collection<JavaClass> testsToRun = testDetector.findTestsToRun(changedFiles);
 		Set<String> newTests = testDetector.getCurrentTests();
@@ -128,8 +149,8 @@ class DefaultInfinitestCore implements InfinitestCore {
 		return testsToRun.size();
 	}
 
-	private Collection<File> findChangedClassFiles() throws IOException {
-		if (changeDetector.filesWereRemoved()) {
+	private Collection<File> findChangedClassFiles(boolean lookForRemovedFiles) throws IOException {
+		if (lookForRemovedFiles && changeDetector.filesWereRemoved()) {
 			// Instead of reloading the core when a file is removed,
 			// we should ask the test detector to remove it from the dependency
 			// graph
@@ -212,7 +233,7 @@ class DefaultInfinitestCore implements InfinitestCore {
 		return runner;
 	}
 
-	private void fireDisabledTestEvents(Set<String> disabledTests) {
+	private void fireDisabledTestEvents(Collection<String> disabledTests) {
 		for (DisabledTestListener each : disabledTestListeners) {
 			each.testsDisabled(disabledTests);
 		}

--- a/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
@@ -94,8 +94,9 @@ class DefaultInfinitestCore implements InfinitestCore {
 	}
 	
 	@Override
-	public void remove(Collection<File> removedFiles) {
-		Set<JavaClass> removedClasses = testDetector.removeClasses(removedFiles);
+	public void remove(Collection<File> removedFiles, Set<JavaClass> removedClasses) {
+		Set<JavaClass> coreRemovedClasses = testDetector.removeClasses(removedFiles);
+		removedClasses.addAll(coreRemovedClasses);
 		
 		fireDisabledTestEvents(classesToNames(removedClasses));
 	}

--- a/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
@@ -76,6 +76,8 @@ public interface InfinitestCore {
 	 * Uses a list of changed files instead of searching for them
 	 */
 	int update(Collection<File> changedFiles);
+	
+	void remove(Collection<File> removedFiles);
 
 	/**
 	 * Re-indexes all the classes in the output directory and re-runs all the

--- a/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
@@ -27,11 +27,14 @@
  */
 package org.infinitest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collection;
+import java.util.Set;
 
 import org.infinitest.environment.RuntimeEnvironment;
-import org.infinitest.testrunner.*;
+import org.infinitest.parser.JavaClass;
+import org.infinitest.testrunner.TestCaseEvent;
+import org.infinitest.testrunner.TestResultsListener;
 
 /**
  * Each core runs tests for a single project (a collection of tests that all
@@ -77,7 +80,7 @@ public interface InfinitestCore {
 	 */
 	int update(Collection<File> changedFiles);
 	
-	void remove(Collection<File> removedFiles);
+	void remove(Collection<File> removedFiles, Set<JavaClass> removedClasses);
 
 	/**
 	 * Re-indexes all the classes in the output directory and re-runs all the

--- a/infinitest-lib/src/main/java/org/infinitest/changedetect/ClassFileFilter.java
+++ b/infinitest-lib/src/main/java/org/infinitest/changedetect/ClassFileFilter.java
@@ -27,15 +27,13 @@
  */
 package org.infinitest.changedetect;
 
-import java.io.*;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
 
-class ClassFileFilter implements FileFilter {
-	@Override
-	public boolean accept(File pathname) {
-		return isClassFile(pathname) || pathname.isDirectory();
-	}
+class ClassFileFilter {
+	private static final Pattern PATTERN = Pattern.compile(".*\\.[Cc][Ll][Aa][Ss][Ss]\\z");
 
-	public static boolean isClassFile(File pathname) {
-		return pathname.getAbsolutePath().matches(".*\\.[Cc][Ll][Aa][Ss][Ss]\\z");
+	public static boolean isClassFile(Path pathname) {
+		return PATTERN.matcher(pathname.toString()).matches();
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/changedetect/ClassFileFilter.java
+++ b/infinitest-lib/src/main/java/org/infinitest/changedetect/ClassFileFilter.java
@@ -30,8 +30,11 @@ package org.infinitest.changedetect;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
-class ClassFileFilter {
+final class ClassFileFilter {
 	private static final Pattern PATTERN = Pattern.compile(".*\\.[Cc][Ll][Aa][Ss][Ss]\\z");
+	
+	private ClassFileFilter() {
+	}
 
 	public static boolean isClassFile(Path pathname) {
 		return PATTERN.matcher(pathname.toString()).matches();

--- a/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
@@ -27,91 +27,84 @@
  */
 package org.infinitest.changedetect;
 
-import static java.lang.Character.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import java.io.*;
-import java.util.*;
-import java.util.logging.*;
-
-import org.infinitest.*;
 import org.infinitest.environment.ClasspathProvider;
-import org.infinitest.util.*;
+import org.infinitest.util.InfinitestUtils;
 
 public class FileChangeDetector implements ChangeDetector {
-	private Map<File, Long> timestampIndex;
-	private File[] classDirectories;
+	private Map<Path, Long> timestampIndex;
+	private List<Path> classDirectories;
 
 	public FileChangeDetector() {
-		classDirectories = new File[0];
-		clear();
+		classDirectories = new ArrayList<>();
+		timestampIndex = new HashMap<>();
 	}
 
 	@Override
 	public void setClasspathProvider(ClasspathProvider classpath) {
 		clear();
 		List<File> classDirs = classpath.classDirectoriesInClasspath();
-		classDirectories = classDirs.toArray(new File[classDirs.size()]);
+		classDirectories = classDirs.stream().map(File::toPath).toList();
 	}
 
 	@Override
 	public synchronized Set<File> findChangedFiles() throws IOException {
-		return findFiles(classDirectories, false);
+		Set<Path> changedFiles = new HashSet<Path>();
+		
+		for (Path root : classDirectories) {
+			try (Stream<Path> stream = Files.walk(root, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)) {
+				stream.forEach(path -> processFile(path, changedFiles));
+			}
+		}
+		
+		return changedFiles.stream().map(Path::toFile).collect(Collectors.toSet());
 	}
 
-	private Set<File> findFiles(File[] classesOrDirectories, boolean isPackage) throws IOException {
-		Set<File> changedFiles = new HashSet<File>();
-		for (File classFileOrDirectory : classesOrDirectories) {
-			if (classFileOrDirectory.isDirectory() && hasValidName(classFileOrDirectory, isPackage)) {
-				findChildren(changedFiles, classFileOrDirectory);
-			} else if (ClassFileFilter.isClassFile(classFileOrDirectory)) {
-				File classFile = classFileOrDirectory;
+	protected void processFile(Path classFile, Set<Path> changedFiles) {
+		try {
+			BasicFileAttributes attributes = readFileAttributes(classFile);
+
+			if (!attributes.isDirectory() && ClassFileFilter.isClassFile(classFile)) {
 				Long timestamp = timestampIndex.get(classFile);
-				if ((timestamp == null) || (getModificationTimestamp(classFile) != timestamp)) {
-					timestampIndex.put(classFile, getModificationTimestamp(classFile));
+				long lastModifiedTime = attributes.lastModifiedTime().toMillis();
+
+				if ((timestamp == null) || (lastModifiedTime != timestamp)) {
+					timestampIndex.put(classFile, lastModifiedTime);
 					changedFiles.add(classFile);
 					InfinitestUtils.log(Level.FINEST, "Class file added to changelist " + classFile);
 				}
 			}
-		}
-		return changedFiles;
-	}
+		} catch (IOException e) {
 
-	private void findChildren(Set<File> changedFiles, File classFileOrDirectory) throws IOException {
-		File[] children = childrenOf(classFileOrDirectory);
-		if (children != null) {
-			changedFiles.addAll(findFiles(children, true));
 		}
 	}
 
-	protected File[] childrenOf(File directory) {
-		return directory.listFiles(new ClassFileFilter());
-	}
-
-	private boolean hasValidName(File classfileOrDirectory, boolean isPackage) {
-		return !isPackage || isJavaIdentifierStart(classfileOrDirectory.getName().charAt(0));
-	}
-
-	protected long getModificationTimestamp(File classFile) {
-		return classFile.lastModified();
+	protected BasicFileAttributes readFileAttributes(Path path) throws IOException {
+		return Files.readAttributes(path, BasicFileAttributes.class);
 	}
 
 	@Override
 	public synchronized void clear() {
-		timestampIndex = new HashMap<File, Long>();
-	}
-
-	private Set<File> findRemovedFiles() {
-		Set<File> removedFiles = new HashSet<File>();
-		for (File key : timestampIndex.keySet()) {
-			if (!key.exists()) {
-				removedFiles.add(key);
-			}
-		}
-		return removedFiles;
+		timestampIndex.clear();
 	}
 
 	@Override
 	public synchronized boolean filesWereRemoved() {
-		return !findRemovedFiles().isEmpty();
+		return timestampIndex.keySet().stream().anyMatch(Files::notExists);
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
@@ -64,7 +64,7 @@ public class FileChangeDetector implements ChangeDetector {
 
 	@Override
 	public synchronized Set<File> findChangedFiles() throws IOException {
-		Set<Path> changedFiles = new HashSet<Path>();
+		Set<Path> changedFiles = new HashSet<>();
 		
 		for (Path root : classDirectories) {
 			try (Stream<Path> stream = Files.walk(root, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)) {
@@ -90,7 +90,7 @@ public class FileChangeDetector implements ChangeDetector {
 				}
 			}
 		} catch (IOException e) {
-
+			throw new IllegalArgumentException("Could not read file attributes of " + classFile, e);
 		}
 	}
 

--- a/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/changedetect/FileChangeDetector.java
@@ -59,7 +59,7 @@ public class FileChangeDetector implements ChangeDetector {
 	public void setClasspathProvider(ClasspathProvider classpath) {
 		clear();
 		List<File> classDirs = classpath.classDirectoriesInClasspath();
-		classDirectories = classDirs.stream().map(File::toPath).toList();
+		classDirectories = classDirs.stream().map(File::toPath).collect(Collectors.toList());
 	}
 
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
@@ -61,6 +61,20 @@ public class ClassFileIndex {
 		graph = new DefaultDirectedGraph<>(DefaultEdge.class);
 		classesByName = new HashMap<>();
 	}
+	
+	public Set<JavaClass> removeClasses(Collection<File> removedFiles) {
+		Set<JavaClass> removedClasses = newHashSet();
+		
+		for (File removedFile : removedFiles) {
+			JavaClass removedClass = builder.classFileRemoved(removedFile);
+			if (removedClass != null) {
+				graph.removeVertex(removedClass);
+				removedClasses.add(removedClass);
+			}
+		}
+		
+		return removedClasses;
+	}
 
 	public Set<JavaClass> findClasses(Collection<File> changedFiles) {
 		// First update class index

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
@@ -66,7 +66,7 @@ public class ClassFileIndex {
 		Set<JavaClass> removedClasses = newHashSet();
 		
 		for (File removedFile : removedFiles) {
-			JavaClass removedClass = builder.classFileRemoved(removedFile);
+			JavaClass removedClass = builder.getClass(removedFile);
 			if (removedClass != null) {
 				graph.removeVertex(removedClass);
 				removedClasses.add(removedClass);

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
@@ -55,6 +55,13 @@ public class ClassFileTestDetector implements TestDetector {
 	public void clear() {
 		index.clear();
 	}
+	
+	@Override
+	public Set<JavaClass> removeClasses(Collection<File> removedFiles) {
+		Set<JavaClass> removeClasses = index.removeClasses(removedFiles);
+		
+		return filterTests(removeClasses);
+	}
 
 	/**
 	 * Runs through the classpath looking for changed files and returns the set

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaClassBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaClassBuilder.java
@@ -27,13 +27,12 @@
  */
 package org.infinitest.parser;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 
-import org.infinitest.MissingClassException;
+import javassist.*;
+
+import org.infinitest.*;
 import org.infinitest.environment.ClasspathProvider;
-
-import javassist.NotFoundException;
 
 /**
  * @author Ben Rady
@@ -65,8 +64,11 @@ class JavaClassBuilder {
 		}
 	}
 	
-	public JavaClass classFileRemoved(File file) {
-		return parser.classFileRemoved(file);
+	/**
+	 * @return The {@link JavaClass} corresponding to this file or null if it was not parsed or does not exist
+	 */
+	public JavaClass getClass(File file) {
+		return parser.getClass(file);
 	}
 
 	public String classFileChanged(File file) {

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaClassBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaClassBuilder.java
@@ -27,12 +27,13 @@
  */
 package org.infinitest.parser;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 
-import javassist.*;
-
-import org.infinitest.*;
+import org.infinitest.MissingClassException;
 import org.infinitest.environment.ClasspathProvider;
+
+import javassist.NotFoundException;
 
 /**
  * @author Ben Rady
@@ -62,6 +63,10 @@ class JavaClassBuilder {
 		} catch (MissingClassException e) {
 			return new UnparsableClass(classname);
 		}
+	}
+	
+	public JavaClass classFileRemoved(File file) {
+		return parser.classFileRemoved(file);
 	}
 
 	public String classFileChanged(File file) {

--- a/infinitest-lib/src/main/java/org/infinitest/parser/TestDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/TestDetector.java
@@ -27,14 +27,20 @@
  */
 package org.infinitest.parser;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collection;
+import java.util.Set;
 
-import org.infinitest.*;
 import org.infinitest.environment.ClasspathProvider;
 
 public interface TestDetector {
 	void clear();
+	
+	/**
+	 * @param removedFiles The removed files
+	 * @return the removed test classes
+	 */
+	Set<JavaClass> removeClasses(Collection<File> removedFiles);
 
 	Set<JavaClass> findTestsToRun(Collection<File> changedFiles);
 

--- a/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
+++ b/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
@@ -88,4 +88,9 @@ public class FakeInfinitestCore implements InfinitestCore {
 	public int update(Collection<File> changedFiles) {
 		throw new UnsupportedOperationException();
 	}
+	
+	@Override
+	public void remove(Collection<File> removedFiles) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
+++ b/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
@@ -31,6 +31,7 @@ import java.io.*;
 import java.util.*;
 
 import org.infinitest.environment.RuntimeEnvironment;
+import org.infinitest.parser.JavaClass;
 import org.infinitest.testrunner.*;
 
 @SuppressWarnings("all")
@@ -90,7 +91,7 @@ public class FakeInfinitestCore implements InfinitestCore {
 	}
 	
 	@Override
-	public void remove(Collection<File> removedFiles) {
+	public void remove(Collection<File> removedFiles, Set<JavaClass> removedClasses) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/StubTestDetector.java
+++ b/infinitest-lib/src/test/java/org/infinitest/StubTestDetector.java
@@ -27,13 +27,15 @@
  */
 package org.infinitest;
 
-import static java.util.Collections.*;
+import static java.util.Collections.emptySet;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collection;
+import java.util.Set;
 
 import org.infinitest.environment.ClasspathProvider;
-import org.infinitest.parser.*;
+import org.infinitest.parser.JavaClass;
+import org.infinitest.parser.TestDetector;
 
 class StubTestDetector implements TestDetector {
 	private boolean cleared;
@@ -45,6 +47,11 @@ class StubTestDetector implements TestDetector {
 
 	public boolean isCleared() {
 		return cleared;
+	}
+	
+	@Override
+	public Set<JavaClass> removeClasses(Collection<File> removedFiles) {
+		return emptySet();
 	}
 
 	@Override

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTestFileIsRemoved.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTestFileIsRemoved.java
@@ -42,6 +42,7 @@ public class WhenTestFileIsRemoved {
 		EventSupport eventSupport = new EventSupport();
 		core.addTestQueueListener(eventSupport);
 		core.update();
+		core.update();
 		eventSupport.assertReloadOccured();
 	}
 

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTriggeringACoreUpdate.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTriggeringACoreUpdate.java
@@ -27,27 +27,39 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Sets.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
-import org.infinitest.parser.*;
-import org.infinitest.testrunner.*;
-import org.junit.*;
+import org.infinitest.changedetect.ChangeDetector;
+import org.infinitest.parser.JavaClass;
+import org.infinitest.parser.TestDetector;
+import org.infinitest.testrunner.TestRunner;
+import org.junit.Before;
+import org.junit.Test;
 
 public class WhenTriggeringACoreUpdate {
-	private List<File> updatedFiles;
+	private Set<File> updatedFiles;
 	private DefaultInfinitestCore core;
+	private ChangeDetector changeDetector;
 	private TestDetector testDetector;
 
 	@Before
-	public void inContext() {
-		updatedFiles = newArrayList();
+	public void inContext() throws IOException {
+		updatedFiles = new HashSet<>();
 		core = new DefaultInfinitestCore(mock(TestRunner.class), new ControlledEventQueue());
+		
+		changeDetector = mock(ChangeDetector.class);
+		when(changeDetector.findChangedFiles()).thenReturn(updatedFiles);
+		core.setChangeDetector(changeDetector);
+		
 		testDetector = mock(TestDetector.class);
 		when(testDetector.getCurrentTests()).thenReturn(Collections.<String> emptySet());
 		core.setTestDetector(testDetector);

--- a/infinitest-lib/src/test/java/org/infinitest/changedetect/WhenLookingForClassFiles.java
+++ b/infinitest-lib/src/test/java/org/infinitest/changedetect/WhenLookingForClassFiles.java
@@ -27,28 +27,23 @@
  */
 package org.infinitest.changedetect;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.io.*;
+import java.nio.file.Path;
 
-import org.junit.*;
+import org.junit.Test;
 
 public class WhenLookingForClassFiles {
-	private ClassFileFilter filter;
-
-	@Before
-	public void inContext() {
-		filter = new ClassFileFilter();
-	}
 
 	@Test
 	public void shouldIgnoreCase() {
-		assertTrue(filter.accept(new File("foo.ClAsS")));
+		assertTrue(ClassFileFilter.isClassFile(Path.of("foo.ClAsS")));
 	}
 
 	@Test
 	public void shouldOnlyFindFilesWithClassExtension() {
-		assertFalse(filter.accept(new File("foo.clas")));
-		assertFalse(filter.accept(new File("fooclass")));
+		assertFalse(ClassFileFilter.isClassFile(Path.of("foo.clas")));
+		assertFalse(ClassFileFilter.isClassFile(Path.of("fooclass")));
 	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/parser/ClassFileIndexTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/ClassFileIndexTest.java
@@ -27,19 +27,24 @@
  */
 package org.infinitest.parser;
 
-import static com.google.common.collect.Lists.*;
-import static java.util.Arrays.*;
-import static org.infinitest.environment.FakeEnvironments.*;
-import static org.infinitest.util.InfinitestTestUtils.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinitest.environment.FakeEnvironments.fakeClasspath;
+import static org.infinitest.util.InfinitestTestUtils.getFileForClass;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
-import com.fakeco.fakeproduct.*;
+import com.fakeco.fakeproduct.FakeProduct;
 
 public class ClassFileIndexTest {
 	private ClassFileIndex index;
@@ -63,6 +68,16 @@ public class ClassFileIndexTest {
 	@Test
 	public void shouldIgnoreClassFilesThatCannotBeParsed() {
 		ClassFileIndex index = new ClassFileIndex(fakeClasspath());
-		assertEquals(Collections.emptySet(), index.findClasses(newArrayList(new File("notAClassFile"))));
+		assertEquals(Collections.emptySet(), index.findClasses(Collections.singleton(new File("notAClassFile"))));
+	}
+	
+	@Test
+	public void removeFiles() {
+		JavaClass javaClass = mock(JavaClass.class);
+		when(builder.classFileRemoved(any())).thenReturn(javaClass);
+		
+		Set<JavaClass> removedClasses = index.removeClasses(Collections.singleton(new File("")));
+		
+		assertThat(removedClasses).contains(javaClass);
 	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/parser/ClassFileIndexTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/ClassFileIndexTest.java
@@ -74,7 +74,7 @@ public class ClassFileIndexTest {
 	@Test
 	public void removeFiles() {
 		JavaClass javaClass = mock(JavaClass.class);
-		when(builder.classFileRemoved(any())).thenReturn(javaClass);
+		when(builder.getClass(any(File.class))).thenReturn(javaClass);
 		
 		Set<JavaClass> removedClasses = index.removeClasses(Collections.singleton(new File("")));
 		

--- a/infinitest-lib/src/test/java/org/infinitest/parser/WhenLookingForChangedFiles.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/WhenLookingForChangedFiles.java
@@ -27,121 +27,135 @@
  */
 package org.infinitest.parser;
 
-import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.infinitest.environment.FakeEnvironments.*;
-import static org.infinitest.util.InfinitestTestUtils.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.infinitest.environment.FakeEnvironments.fakeBuildPaths;
+import static org.infinitest.util.InfinitestTestUtils.getFileForClass;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
-import org.infinitest.*;
-import org.infinitest.changedetect.*;
+import org.infinitest.StandaloneClasspath;
+import org.infinitest.changedetect.ChangeDetector;
+import org.infinitest.changedetect.FileChangeDetector;
 import org.infinitest.environment.ClasspathProvider;
-import org.infinitest.util.*;
-import org.junit.*;
-import org.junit.rules.*;
+import org.infinitest.util.InfinitestTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import com.fakeco.fakeproduct.*;
+import com.fakeco.fakeproduct.FakeProduct;
+import com.fakeco.fakeproduct.TestFakeProduct;
 
 public class WhenLookingForChangedFiles {
-  private File altClassDir;
-  private ChangeDetector detector;
-  protected long timestamp;
-  private ClasspathProvider classpath;
+	private File altClassDir;
+	private ChangeDetector detector;
+	private ClasspathProvider classpath;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @Before
-  public void inContext() throws IOException {
-    altClassDir = temporaryFolder.newFolder("altClasses");
-    List<File> buildPaths = new ArrayList<File>();
-    buildPaths.addAll(fakeBuildPaths());
-    buildPaths.add(altClassDir);
-    classpath = new StandaloneClasspath(buildPaths);
-    detector = new FileChangeDetector();
-    detector.setClasspathProvider(classpath);
-  }
+	@Before
+	public void inContext() throws IOException {
+		altClassDir = temporaryFolder.newFolder("altClasses");
+		List<File> buildPaths = new ArrayList<File>();
+		buildPaths.addAll(fakeBuildPaths());
+		buildPaths.add(altClassDir);
+		classpath = new StandaloneClasspath(buildPaths);
+		detector = new FileChangeDetector();
+		detector.setClasspathProvider(classpath);
+	}
 
-  @Test
-  public void shouldLookInClasspathForFiles() {
-    ClasspathProvider mockClasspath = mock(ClasspathProvider.class);
+	@Test
+	public void shouldLookInClasspathForFiles() {
+		ClasspathProvider mockClasspath = mock(ClasspathProvider.class);
 
-    new FileChangeDetector().setClasspathProvider(mockClasspath);
+		new FileChangeDetector().setClasspathProvider(mockClasspath);
 
-    verify(mockClasspath).classDirectoriesInClasspath();
-  }
+		verify(mockClasspath).classDirectoriesInClasspath();
+	}
 
-  @Test
-  public void shouldHandleStrangeClasspaths() throws Exception {
-    ChangeDetector changeDetector = new FileChangeDetector();
-    changeDetector.setClasspathProvider(new StandaloneClasspath(new ArrayList<File>(), ""));
-    assertTrue(changeDetector.findChangedFiles().isEmpty());
-  }
+	@Test
+	public void shouldHandleStrangeClasspaths() throws Exception {
+		ChangeDetector changeDetector = new FileChangeDetector();
+		changeDetector.setClasspathProvider(new StandaloneClasspath(new ArrayList<File>(), ""));
+		assertTrue(changeDetector.findChangedFiles().isEmpty());
+	}
 
-  @Test
-  public void shouldFindChangedFiles() throws IOException {
-    Set<File> files = detector.findChangedFiles();
+	@Test
+	public void shouldFindChangedFiles() throws IOException {
+		Set<File> files = detector.findChangedFiles();
 
-    assertThat(files).contains(getFileForClass(TestFakeProduct.class));
-    assertThat(files).contains(getFileForClass(FakeProduct.class));
-    assertThat(detector.findChangedFiles()).isEmpty();
-  }
+		assertThat(files).contains(getFileForClass(TestFakeProduct.class));
+		assertThat(files).contains(getFileForClass(FakeProduct.class));
+		assertThat(detector.findChangedFiles()).isEmpty();
+	}
 
-  @Test
-  public void canLookInMultipleClassDirectories() throws Exception {
-    File newFile = createFileForClass(TestFakeProduct.class);
-    File thisFile = InfinitestTestUtils.getFileForClass(getClass());
-    Set<File> changedFiles = detector.findChangedFiles();
+	@Test
+	public void canLookInMultipleClassDirectories() throws Exception {
+		File newFile = createFileForClass(TestFakeProduct.class);
+		File thisFile = InfinitestTestUtils.getFileForClass(getClass());
+		Set<File> changedFiles = detector.findChangedFiles();
 
-    assertThat(changedFiles).contains(newFile, thisFile);
-  }
+		assertThat(changedFiles).contains(newFile, thisFile);
+	}
 
-  @Test
-  public void shouldFindRemovedFiles() throws Exception {
-    File newFile = createFileForClass(TestFakeProduct.class);
-    assertThat(detector.findChangedFiles()).contains(newFile);
+	@Test
+	public void shouldFindRemovedFiles() throws Exception {
+		File newFile = createFileForClass(TestFakeProduct.class);
+		assertThat(detector.findChangedFiles()).contains(newFile);
 
-    newFile.delete();
+		newFile.delete();
 
-    assertTrue(detector.filesWereRemoved());
-    assertThat(detector.findChangedFiles()).doesNotContain(newFile);
-  }
+		assertTrue(detector.filesWereRemoved());
+		assertThat(detector.findChangedFiles()).doesNotContain(newFile);
+	}
 
-  @Test
-  public void shouldDetectChangedFilesByTimeStamp() throws Exception {
-    detector = new FileChangeDetector() {
-      @Override
-      protected long getModificationTimestamp(File classFile) {
-        return timestamp;
-      }
-    };
-    detector.setClasspathProvider(classpath);
-    assertFalse("Should have found changed files on first run", detector.findChangedFiles().isEmpty());
-    assertTrue("Timestamp is unchanged", detector.findChangedFiles().isEmpty());
-    timestamp += 100;
-    assertFalse("Timestamp changed", detector.findChangedFiles().isEmpty());
-  }
+	@Test
+	public void shouldDetectChangedFilesByTimeStamp() throws Exception {
+		BasicFileAttributes directoryAttributes = mock(BasicFileAttributes.class);
+		BasicFileAttributes classFileAttributes = mock(BasicFileAttributes.class);
 
-  @Test
-  public void shouldBeTolerantOfDissapearingDirectories() throws Exception {
-    detector = new FileChangeDetector() {
-      @Override
-      protected File[] childrenOf(File directory) {
-        return null;
-      }
-    };
-    detector.setClasspathProvider(classpath);
-    assertEquals(emptySet(), detector.findChangedFiles());
-  }
+		when(directoryAttributes.isDirectory()).thenReturn(true);
+		when(classFileAttributes.lastModifiedTime()).thenReturn(FileTime.fromMillis(1000L));
 
-  private File createFileForClass(Class<TestFakeProduct> clazz) throws IOException {
-    File destFile = InfinitestTestUtils.getFileForClass(altClassDir, clazz.getName());
-    assertTrue(destFile.getParentFile().mkdirs());
-    assertTrue(destFile.createNewFile());
-    return destFile;
-  }
+		detector = new FileChangeDetector() {
+			@Override
+			protected BasicFileAttributes readFileAttributes(Path path) throws IOException {
+				if (Files.isDirectory(path)) {
+					return directoryAttributes;
+				} else {
+					return classFileAttributes;
+				}
+			}
+		};
+		
+		detector.setClasspathProvider(classpath);
+		assertFalse("Should have found changed files on first run", detector.findChangedFiles().isEmpty());
+		assertTrue("Timestamp is unchanged", detector.findChangedFiles().isEmpty());
+
+		// Update the timestamp of the file from 1000 to 1100
+		when(classFileAttributes.lastModifiedTime()).thenReturn(FileTime.fromMillis(1100L));
+
+		assertFalse("Timestamp changed", detector.findChangedFiles().isEmpty());
+	}
+
+	private File createFileForClass(Class<TestFakeProduct> clazz) throws IOException {
+		File destFile = InfinitestTestUtils.getFileForClass(altClassDir, clazz.getName());
+		assertTrue(destFile.getParentFile().mkdirs());
+		assertTrue(destFile.createNewFile());
+		return destFile;
+	}
 }


### PR DESCRIPTION
Biggest performance bottleneck is calling file.lastModified() twice for every file when a change is made, file.isDirectory() is also expensive

- Use java nio's BasicFileAttributes to read the last modified time (see #12)
- Use Files.walk to search the folders
- Monitor for post build events so we run tests once everything is built (see #340)
- Check for removed tests (see #337)