### PR TITLE
deps: upgrade javassist to 3.29.2

### DIFF
--- a/infinitest-lib/pom.xml
+++ b/infinitest-lib/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.18.2-GA</version>
+			<version>${javassist.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
+		<javassist.version>3.29.2-GA</javassist.version>
 		<mockito.version>4.7.0</mockito.version>
 		<junit.version>4.12</junit.version>
 		<junit5.version>5.0.3</junit5.version>


### PR DESCRIPTION
3.18.2 is quite old and the new version is much faster (see #12), reduces by 80% the time it spent (~1mn) to parse the java classes on a sample largeish project