### PR TITLE
fix: use the built-in utility to compute the working dir of a module

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -40,6 +40,8 @@ import org.infinitest.intellij.InfinitestJarsLocator;
 import org.infinitest.intellij.ModuleSettings;
 import org.jetbrains.annotations.Nullable;
 
+import com.intellij.execution.CommonProgramRunConfigurationParameters;
+import com.intellij.execution.util.ProgramParametersConfigurator;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.compiler.CompilerPaths;
@@ -149,7 +151,12 @@ public class IdeaModuleSettings implements ModuleSettings {
 	}
 
 	private File getWorkingDirectory() {
-		return new File(module.getModuleFilePath()).getParentFile();
+		CommonProgramRunConfigurationParameters configuration = new InfinitestRunConfigurationParameters();
+		
+		ProgramParametersConfigurator configurator = new ProgramParametersConfigurator();
+		String workingDir = configurator.getWorkingDir(configuration, module.getProject(), module);
+		
+		return new File(workingDir);
 	}
 
 	/**

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/InfinitestRunConfigurationParameters.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/InfinitestRunConfigurationParameters.java
@@ -1,0 +1,95 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.intellij.idea;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.execution.CommonProgramRunConfigurationParameters;
+import com.intellij.openapi.project.Project;
+
+/**
+ * ProgramParametersConfigurator.getWorkingDir only calls getWorkingDirectory and we want this to return null
+ * The interface is implemented but it does not seem to be necessary in the current version of IDEA
+ * 
+ * In a future version it might be good to actually implement a run configuration and let the user configure the
+ * runner from there
+ */
+public class InfinitestRunConfigurationParameters implements CommonProgramRunConfigurationParameters {
+	private String programParameters;
+	private String workingDirectory;
+	private Map<String, String> envs;
+	private boolean passParentEnvs;
+	
+	@Override
+	public Project getProject() {
+		return null;
+	}
+
+	@Override
+	public void setProgramParameters(@Nullable String value) {
+		this.programParameters = value;
+	}
+
+	@Override
+	public @Nullable String getProgramParameters() {
+		return programParameters;
+	}
+
+	@Override
+	public void setWorkingDirectory(@Nullable String value) {
+		this.workingDirectory = value;
+	}
+
+	@Override
+	public @Nullable String getWorkingDirectory() {
+		return workingDirectory;
+	}
+
+	@Override
+	public void setEnvs(@NotNull Map<String, String> envs) {
+		this.envs = envs;
+	}
+
+	@Override
+	public @NotNull Map<String, String> getEnvs() {
+		return envs;
+	}
+
+	@Override
+	public void setPassParentEnvs(boolean passParentEnvs) {
+		this.passParentEnvs = passParentEnvs;
+	}
+
+	@Override
+	public boolean isPassParentEnvs() {
+		return passParentEnvs;
+	}
+}


### PR DESCRIPTION
- module.getModuleFilePath() is an internal method and shouldn't be used by plugins, according to the javadoc the path returned might not exist
- instead use ProgramParametersConfigurator with a mock/null configuration
- can't seem to be possible to use MacroManager so no unit test for this change
- fixes #344