### PR TITLE
fix: explicitely set java level to 11 for the intellij module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ You can pull only a shallow clone by specifying the number of commits you want w
 
 ## Build
 
+Infinitest is on Java 8, except for the `infinitest-intellij` module which is on Java 11, so a JDK >= 11 is required for building.
 You need [Maven](http://maven.apache.org/download.html). To run a reactor build in the repository root: 
 
 	mvn clean install

--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -13,6 +13,8 @@
   <properties>
     <intellij.version>20.1.0</intellij.version>
     <intellij.api.version>221.5787.30</intellij.api.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <repositories>
@@ -140,6 +142,10 @@
         <exclusion>
           <groupId>io.ktor</groupId>
         <artifactId>ktor-network-jvm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ws.xmlrpc</groupId>
+          <artifactId>xmlrpc</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
- set the java version to 11
- exclude transitive dependency containing the org.xml.sax package
- Updated docs with JDK requirements