### PR TITLE
fix: set the core name from the constructor instead of a setter

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/CoreFactory.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/CoreFactory.java
@@ -48,9 +48,8 @@ class CoreFactory implements CoreSettings {
 	}
 
 	public InfinitestCore createCore(String projectName, RuntimeEnvironment environment) {
-		InfinitestCoreBuilder coreBuilder = new InfinitestCoreBuilder(environment, eventQueue);
+		InfinitestCoreBuilder coreBuilder = new InfinitestCoreBuilder(environment, eventQueue, projectName);
 		coreBuilder.setUpdateSemaphore(concurrencyController);
-		coreBuilder.setName(projectName);
 
 		return coreBuilder.createCore();
 	}

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/InfinitestLauncherImpl.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/launcher/InfinitestLauncherImpl.java
@@ -45,8 +45,7 @@ public class InfinitestLauncherImpl implements InfinitestLauncher {
 	 */
 	public InfinitestLauncherImpl(Module module) {
 		ModuleSettings moduleSettings = module.getService(ModuleSettings.class);
-		InfinitestCoreBuilder coreBuilder = new InfinitestCoreBuilder(moduleSettings.getRuntimeEnvironment(), new SwingEventQueue());
-		coreBuilder.setName(moduleSettings.getName());
+		InfinitestCoreBuilder coreBuilder = new InfinitestCoreBuilder(moduleSettings.getRuntimeEnvironment(), new SwingEventQueue(), moduleSettings.getName());
 		core = coreBuilder.createCore();
 		resultCollector = new ResultCollector(core);
 		

--- a/infinitest-lib/src/main/java/org/infinitest/InfinitestCoreBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/InfinitestCoreBuilder.java
@@ -50,14 +50,15 @@ public class InfinitestCoreBuilder {
 	private final Class<? extends TestRunner> runnerClass;
 	private final RuntimeEnvironment runtimeEnvironment;
 	private final EventQueue eventQueue;
-	private String coreName = "";
+	private String coreName;
 	private ConcurrencyController controller;
 
-	public InfinitestCoreBuilder(RuntimeEnvironment environment, EventQueue eventQueue) {
-		checkNotNull(environment, "No runtime environment is configured. Maybe because the project has no jdk.");
+	public InfinitestCoreBuilder(RuntimeEnvironment environment, EventQueue eventQueue, String coreName) {
+		checkNotNull(environment, "No runtime environment is configured. Maybe because " + coreName + " has no jdk.");
 
 		runtimeEnvironment = environment;
 		this.eventQueue = eventQueue;
+		this.coreName = coreName;
 		
 		InfinitestConfigurationSource configSource = FileBasedInfinitestConfigurationSource.createFromWorkingDirectory(environment.getWorkingDirectory());
 		filterList = new RegexFileFilter(configSource);
@@ -100,10 +101,6 @@ public class InfinitestCoreBuilder {
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Cannot access runner class " + runnerClass, e);
 		}
-	}
-
-	public void setName(String coreName) {
-		this.coreName = coreName;
 	}
 
 	public void setUpdateSemaphore(ConcurrencyController semaphore) {

--- a/infinitest-lib/src/test/java/org/infinitest/plugin/WhenConfiguringBuilder.java
+++ b/infinitest-lib/src/test/java/org/infinitest/plugin/WhenConfiguringBuilder.java
@@ -52,13 +52,13 @@ class WhenConfiguringBuilder {
 	@BeforeEach
 	final void mustProvideRuntimeEnvironmentAndEventQueue() {
 		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(), systemClasspath(), systemClasspath(), fakeBuildPaths(), systemClasspath());
-		builder = new InfinitestCoreBuilder(environment, new FakeEventQueue());
+		builder = new InfinitestCoreBuilder(environment, new FakeEventQueue(), "myCoreName");
 	}
 
 	@Test
 	void canUseCustomFilterToRemoveTestsFromTestRun() {
 		TestFilter testFilter = mock(TestFilter.class);
-		builder = new InfinitestCoreBuilder(fakeEnvironment(), new FakeEventQueue()) {
+		builder = new InfinitestCoreBuilder(fakeEnvironment(), new FakeEventQueue(), "myCoreName") {
 			@Override
 			protected TestDetector createTestDetector(TestFilter testFilter) {
 				filterUsedToCreateCore = testFilter;
@@ -72,15 +72,8 @@ class WhenConfiguringBuilder {
 
 	@Test
 	void canSetCoreName() {
-		builder.setName("myCoreName");
 		InfinitestCore core = builder.createCore();
 		assertEquals("myCoreName", core.getName());
-	}
-
-	@Test
-	void shouldUseBlankCoreNameByDefault() {
-		InfinitestCore core = builder.createCore();
-		assertEquals("", core.getName());
 	}
 
 	@Test

--- a/infinitest-lib/src/test/java/org/infinitest/plugin/WhenRunningTests.java
+++ b/infinitest-lib/src/test/java/org/infinitest/plugin/WhenRunningTests.java
@@ -58,7 +58,7 @@ class WhenRunningTests {
   @BeforeAll
   static void inContext() throws InterruptedException {
     if (eventHistory == null) {
-      InfinitestCoreBuilder builder = new InfinitestCoreBuilder(fakeEnvironment(), new FakeEventQueue());
+      InfinitestCoreBuilder builder = new InfinitestCoreBuilder(fakeEnvironment(), new FakeEventQueue(), "myCoreName");
       builder.setUpdateSemaphore(mock(ConcurrencyController.class));
 
       TestFilter testFilter = mock(TestFilter.class);


### PR DESCRIPTION
we always seem to call setName() after the constructor, so add an argument to the constructor instead so we can add the core name to the error message
see #357