### PR TITLE
fix: use diamond operator, removed unnecessary usage of guava

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SwtEventQueue.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SwtEventQueue.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.*;
 
 @Component
 public class SwtEventQueue implements EventQueue {
-	private final BlockingQueue<NamedRunnable> runnableQueue = new LinkedBlockingQueue<NamedRunnable>();
+	private final BlockingQueue<NamedRunnable> runnableQueue = new LinkedBlockingQueue<>();
 	private Job job;
 
 	public SwtEventQueue() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/TestResultAggregator.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/TestResultAggregator.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Arrays.*;
 
 import java.util.*;
@@ -39,7 +38,7 @@ import org.springframework.stereotype.*;
 
 @Component
 public class TestResultAggregator implements CoreLifecycleListener, TestResultsListener {
-	private final List<TestResultsListener> listeners = newArrayList();
+	private final List<TestResultsListener> listeners = new ArrayList<>();
 
 	@Autowired
 	public void addListeners(AggregateResultsListener... resultsListeners) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/CoreUpdateNotifier.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/CoreUpdateNotifier.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.event;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Arrays.*;
 
 import java.util.*;
@@ -45,7 +44,7 @@ class CoreUpdateNotifier implements IResourceChangeListener {
 	@Autowired
 	CoreUpdateNotifier(EventQueue queue) {
 		this.queue = queue;
-		processors = newArrayList();
+		processors = new ArrayList<>();
 	}
 
 	@Autowired

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
@@ -27,16 +27,12 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Sets.*;
 import static org.infinitest.util.InfinitestUtils.*;
 
 import java.util.*;
 
 import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
-
-import com.google.common.collect.*;
 
 /**
  * This would be a nice feature someday: <a
@@ -50,7 +46,7 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 
 	public GenericMarkerRegistry(String markerId) {
 		this.markerId = markerId;
-		markers = Maps.newHashMap();
+		markers = new HashMap<>();
 	}
 
 	@Override
@@ -99,7 +95,7 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 
 	private Set<MarkerInfo> copyOf(Set<MarkerInfo> keySet) {
 		// Make a copy to prevent concurrent modification while deleting markers
-		return newHashSet(keySet);
+		return new HashSet<>(keySet);
 	}
 
 	@Override
@@ -119,7 +115,7 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 	}
 
 	private Iterable<MarkerInfo> findMarkersFor(String testName) {
-		List<MarkerInfo> markersFound = newArrayList();
+		List<MarkerInfo> markersFound = new ArrayList<>();
 		for (MarkerInfo each : markers.keySet()) {
 			if (each.getTestName().equals(testName)) {
 				markersFound.add(each);

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/MarkerPlacer.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/MarkerPlacer.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Collections.*;
 
 import java.util.*;
@@ -39,7 +38,7 @@ import org.springframework.stereotype.*;
 
 @Component
 public class MarkerPlacer {
-	private final List<MarkerPlacementStrategy> placementStrategyChain = newArrayList();
+	private final List<MarkerPlacementStrategy> placementStrategyChain = new ArrayList<>();
 
 	@Autowired
 	public MarkerPlacer(ResourceLookup lookup) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ResourceLookupAdapter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ResourceLookupAdapter.java
@@ -28,6 +28,7 @@
 package org.infinitest.eclipse.markers;
 
 import static com.google.common.collect.Lists.*;
+import static java.util.Collections.singletonList;
 
 import java.util.*;
 
@@ -49,10 +50,10 @@ public class ResourceLookupAdapter implements ResourceLookup {
 	public List<IResource> findResourcesForClassName(String className) {
 		IResource resource = finder.findResourceForSourceFile(sourceFilename(className));
 		if (resource == null) {
-			return newArrayList();
+			return new ArrayList<>();
 		}
 
-		return newArrayList(resource);
+		return singletonList(resource);
 	}
 
 	private static String sourceFilename(String className) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ResourceLookupAdapter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ResourceLookupAdapter.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Collections.singletonList;
 
 import java.util.*;

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/ErrorViewerResolution.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/ErrorViewerResolution.java
@@ -27,7 +27,7 @@
  */
 package org.infinitest.eclipse.resolution;
 
-import static com.google.common.collect.Lists.*;
+import static java.util.Arrays.asList;
 import static org.eclipse.core.resources.IMarker.*;
 import static org.infinitest.eclipse.markers.ProblemMarkerInfo.*;
 import static org.infinitest.eclipse.util.PickleJar.*;
@@ -71,7 +71,7 @@ public class ErrorViewerResolution implements IMarkerResolution2 {
 	public void run(IMarker marker) {
 		try {
 			Serializable unpickledStack = unpickle(marker.getAttribute(PICKLED_STACK_TRACE_ATTRIBUTE).toString());
-			List<StackTraceElement> stackTrace = newArrayList((StackTraceElement[]) unpickledStack);
+			List<StackTraceElement> stackTrace = asList((StackTraceElement[]) unpickledStack);
 			createStackViewWith(stackTrace, marker.getAttribute(MESSAGE).toString());
 		} catch (CoreException e) {
 			throw new RuntimeException(e);

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/StackTraceFilter.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/resolution/StackTraceFilter.java
@@ -27,8 +27,6 @@
  */
 package org.infinitest.eclipse.resolution;
 
-import static com.google.common.collect.Lists.*;
-
 import java.util.*;
 import java.util.regex.*;
 
@@ -41,8 +39,12 @@ public class StackTraceFilter {
       Pattern.compile("java\\.lang\\.reflect\\.Method")
   };
 
+  public List<StackTraceElement> filterStack(StackTraceElement ... elements) {
+    return filterStack(Arrays.asList(elements));
+  }
+
   public List<StackTraceElement> filterStack(List<StackTraceElement> stackTrace) {
-    List<StackTraceElement> filtered = newArrayList();
+    List<StackTraceElement> filtered = new ArrayList<>();
 
     for (StackTraceElement each : stackTrace) {
       if (!match(each.getClassName())) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/status/StatusEventSupport.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/status/StatusEventSupport.java
@@ -27,12 +27,10 @@
  */
 package org.infinitest.eclipse.status;
 
-import static com.google.common.collect.Lists.*;
-
 import java.util.*;
 
 public class StatusEventSupport {
-	private final List<StatusEventListener> listeners = newArrayList();
+	private final List<StatusEventListener> listeners = new ArrayList<>();
 
 	public void addListener(StatusEventListener listener) {
 		listeners.add(listener);

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ClassPathResolver.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ClassPathResolver.java
@@ -60,7 +60,7 @@ public class ClassPathResolver {
 	}
 
 	Iterable<String> unresolvedRuntimeClasspath(IJavaProject project) throws CoreException {
-		List<String> jars = Lists.newArrayList();
+		List<String> jars = new ArrayList<>();
 
 		for (IRuntimeClasspathEntry runtimeEntry : eclipseFacade.computeUnresolvedRuntimeClasspath(project)) {
 			String variable = runtimeEntry.getVariableName();

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/InfinitestCoreRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/InfinitestCoreRegistry.java
@@ -27,8 +27,6 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
 import static org.infinitest.util.InfinitestUtils.*;
 
 import java.net.*;
@@ -41,8 +39,8 @@ import org.springframework.stereotype.*;
 
 @Component
 class InfinitestCoreRegistry implements CoreRegistry {
-	private final Map<URI, InfinitestCore> coreMap = newHashMap();
-	private final List<CoreLifecycleListener> listeners = newArrayList();
+	private final Map<URI, InfinitestCore> coreMap = new HashMap<>();
+	private final List<CoreLifecycleListener> listeners = new ArrayList<>();
 
 	@Autowired
 	InfinitestCoreRegistry(CoreLifecycleListener... listeners) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/JavaProjectSet.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/JavaProjectSet.java
@@ -28,7 +28,6 @@
 package org.infinitest.eclipse.workspace;
 
 import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Lists.*;
 
 import java.io.*;
 import java.util.*;
@@ -39,7 +38,6 @@ import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
 
 import com.google.common.base.*;
-import com.google.common.collect.*;
 
 @Component
 class JavaProjectSet implements ProjectSet {
@@ -71,7 +69,7 @@ class JavaProjectSet implements ProjectSet {
 
 	@Override
 	public List<ProjectFacade> projects() {
-		List<ProjectFacade> projects = newArrayList();
+		List<ProjectFacade> projects = new ArrayList<>();
 		for (IJavaProject project : openProjects()) {
 			projects.add(new ProjectFacade(project));
 		}
@@ -116,7 +114,7 @@ class JavaProjectSet implements ProjectSet {
 	}
 
 	private List<File> customOutputDirectoriesFor(EclipseProject project) {
-		List<File> outputDirectories = Lists.newArrayList();
+		List<File> outputDirectories = new ArrayList<>();
 		for (IClasspathEntry each : project.getClasspathEntries()) {
 			IPath outputLocation = each.getOutputLocation();
 			if (outputLocation != null) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/FailureMediatorTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/FailureMediatorTest.java
@@ -27,7 +27,8 @@
  */
 package org.infinitest.eclipse;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.infinitest.testrunner.TestEvent.methodFailed;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -64,8 +65,8 @@ class FailureMediatorTest {
 
 	@Test
 	void shouldRelayAddRemoveEvents() {
-		Collection<TestEvent> failuresAdded = newArrayList(event1, event2);
-		Collection<TestEvent> failuresRemoved = newArrayList(event3);
+		Collection<TestEvent> failuresAdded = asList(event1, event2);
+		Collection<TestEvent> failuresRemoved = singletonList(event3);
 
 		mediator.failureListChanged(failuresAdded, failuresRemoved);
 
@@ -76,7 +77,7 @@ class FailureMediatorTest {
 
 	@Test
 	void shouldRelayUpdateEvents() {
-		Collection<TestEvent> updatedFailures = newArrayList(event1, event2);
+		Collection<TestEvent> updatedFailures = asList(event1, event2);
 
 		mediator.failuresUpdated(updatedFailures);
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenPlacingMarkersInOriginatingTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenPlacingMarkersInOriginatingTest.java
@@ -27,7 +27,7 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.singletonList;
 import static org.infinitest.testrunner.TestEvent.TestState.METHOD_FAILURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -59,7 +59,7 @@ class WhenPlacingMarkersInOriginatingTest {
 
 	@Test
 	void shouldUseTestNameInEvent() {
-		when(lookup.findResourcesForClassName(TEST_NAME)).thenReturn(newArrayList(testResource));
+		when(lookup.findResourcesForClassName(TEST_NAME)).thenReturn(singletonList(testResource));
 
 		MarkerPlacement placement = strategy.getPlacement(event);
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/FailureViewerTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/FailureViewerTest.java
@@ -27,7 +27,8 @@
  */
 package org.infinitest.eclipse.resolution;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.swt.SWT.Deactivate;
 import static org.eclipse.swt.SWT.KeyDown;
@@ -54,7 +55,7 @@ class FailureViewerTest {
 	@BeforeEach
 	void inContext() {
 		element = new StackTraceElement("class1", "method1", "file1", 0);
-		view = new FailureViewer(null, "message", newArrayList(element), null);
+		view = new FailureViewer(null, "message", singletonList(element), null);
 		dialog = new FakeShell();
 		view.show(dialog);
 		list = (List) dialog.getChildren()[1];
@@ -113,7 +114,7 @@ class FailureViewerTest {
 
 		Throwable throwable = buildAFakeStackTraceRecursively(100);
 		String msg = "Hello, this is a really long error message that is supposed to demonstrate how well we can" + " wrap long error messages. Evidently, they need to be long than what I've typed here";
-		Shell dialog = new FailureViewer(shell, msg, newArrayList(throwable.getStackTrace()), new FakeResourceFinder()).show();
+		Shell dialog = new FailureViewer(shell, msg, asList(throwable.getStackTrace()), new FakeResourceFinder()).show();
 		while (!shell.isDisposed() && !dialog.isDisposed()) {
 			if (!display.readAndDispatch()) {
 				display.sleep();

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenAStackTraceElementIsSelected.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenAStackTraceElementIsSelected.java
@@ -47,8 +47,6 @@ import org.infinitest.eclipse.workspace.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.*;
-
 class WhenAStackTraceElementIsSelected {
 	private FakeShell shell;
 	private KeyEvent keyEvent;
@@ -63,7 +61,7 @@ class WhenAStackTraceElementIsSelected {
 	@BeforeEach
 	void inContext() {
 		shell = new FakeShell();
-		stackTrace = Lists.newArrayList();
+		stackTrace = new ArrayList<>();
 		stackTrace.add(new StackTraceElement("MyClassName", "someMethod", "MyClassName.java", 72));
 		resourceLookup = mock(ResourceLookup.class);
 		listener = new StackElementSelectionListener(shell, resourceLookup, stackTrace) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenDisplayingTestFailureDetails.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenDisplayingTestFailureDetails.java
@@ -28,7 +28,6 @@
 package org.infinitest.eclipse.resolution;
 
 import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Lists.*;
 import static org.eclipse.core.resources.IMarker.*;
 import static org.infinitest.eclipse.markers.ProblemMarkerInfo.*;
 import static org.infinitest.eclipse.util.PickleJar.*;
@@ -48,7 +47,7 @@ class WhenDisplayingTestFailureDetails {
 
 	@BeforeEach
 	void inContext() {
-		actualStackTrace = newArrayList();
+		actualStackTrace = new ArrayList<>();
 		resolution = new ErrorViewerResolution("TestName.methodName") {
 			@Override
 			protected void createStackViewWith(List<StackTraceElement> trace, String message) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenFilteringUnnecessaryClassesFromStackTraces.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/resolution/WhenFilteringUnnecessaryClassesFromStackTraces.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.resolution;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,22 +44,22 @@ class WhenFilteringUnnecessaryClassesFromStackTraces {
 
 	@Test
 	void shouldRemoveInfinitestRunnerClasses() {
-		assertEquals(emptyList(), filter.filterStack(newArrayList(element("org.infinitest.runner.Foobar"))));
+		assertEquals(emptyList(), filter.filterStack(element("org.infinitest.runner.Foobar")));
 	}
 
 	@Test
 	void shouldNotRemoveRegularInfinitestClasses() {
-		assertThat(filter.filterStack(newArrayList(element("org.infinitest.Foobar")))).isNotEmpty();
+		assertThat(filter.filterStack(element("org.infinitest.Foobar"))).isNotEmpty();
 	}
 
 	@Test
 	void shouldRemoveJUnitClasses() {
-		assertEquals(emptyList(), filter.filterStack(newArrayList(element("org.junit.Foobar"), element("junit.framework.Foobar"))));
+		assertEquals(emptyList(), filter.filterStack(element("org.junit.Foobar"), element("junit.framework.Foobar")));
 	}
 
 	@Test
 	void shouldRemoveSunReflectionClasses() {
-		assertEquals(emptyList(), filter.filterStack(newArrayList(element("sun.reflect.Foo"), element("java.lang.reflect.Method"))));
+		assertEquals(emptyList(), filter.filterStack(element("sun.reflect.Foo"), element("java.lang.reflect.Method")));
 	}
 
 	private StackTraceElement element(String classname) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/util/WhenStoringObjectsAsStrings.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/util/WhenStoringObjectsAsStrings.java
@@ -27,7 +27,7 @@
  */
 package org.infinitest.eclipse.util;
 
-import static com.google.common.collect.Lists.*;
+import static java.util.Arrays.asList;
 import static org.infinitest.eclipse.util.PickleJar.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -42,7 +42,7 @@ class WhenStoringObjectsAsStrings {
 
 	@Test
 	void canPickleListsOfObjects() {
-		String stringForm = pickle(newArrayList("Hello", "There").toString());
-		assertEquals(newArrayList("Hello", "There").toString(), unpickle(stringForm));
+		String stringForm = pickle(asList("Hello", "There").toString());
+		assertEquals(asList("Hello", "There").toString(), unpickle(stringForm));
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/FakeResourceFinder.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/FakeResourceFinder.java
@@ -27,7 +27,7 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
+import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static org.infinitest.eclipse.workspace.JavaProjectBuilder.*;
 import static org.mockito.Mockito.*;
@@ -48,7 +48,7 @@ public class FakeResourceFinder implements ResourceFinder, ResourceLookup {
 	}
 
 	public FakeResourceFinder(IJavaProject... projects) {
-		this(newArrayList(projects));
+		this(asList(projects));
 	}
 
 	@Override

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectBuilder.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.eclipse.core.resources.IResource.DEPTH_INFINITE;
 import static org.eclipse.jdt.core.IClasspathEntry.CPE_LIBRARY;
 import static org.eclipse.jdt.core.IClasspathEntry.CPE_PROJECT;
@@ -42,6 +41,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -87,7 +87,7 @@ public class JavaProjectBuilder implements IJavaProject {
 
 	private JavaProjectBuilder(String projectName) {
 		this.projectName = projectName;
-		entries = newArrayList();
+		entries = new ArrayList<>();
 	}
 
 	public JavaProjectBuilder withJar(String jarName) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectSetTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/JavaProjectSetTest.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static com.google.common.collect.Lists.*;
 import static org.infinitest.eclipse.workspace.JavaProjectBuilder.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -52,14 +51,14 @@ class JavaProjectSetTest {
 
 		project = project("projectA").withJar("lib/someJarFile").andExportedJar("lib/someExportedJarFile").andExtenralJar(externalJarPath).andSourceDirectory("src", "srcbin").andDependsOn("projectB");
 		ResourceFinder finder = mock(ResourceFinder.class);
-		List<IJavaProject> projects = newArrayList(project);
+		List<IJavaProject> projects = Collections.singletonList(project);
 		when(finder.getJavaProjects()).thenReturn(projects);
 		projectSet = new JavaProjectSet(finder);
 	}
 
 	@Test
 	void shouldProvideOutputDirectoriesForProjectAsAbsolutePaths() throws JavaModelException {
-		ArrayList<File> expectedDirectories = newArrayList(new File("/root/projectA/srcbin"), new File("/root/projectA/target/classes"));
+		List<File> expectedDirectories = Arrays.asList(new File("/root/projectA/srcbin"), new File("/root/projectA/target/classes"));
 
 		assertEquals(expectedDirectories, projectSet.outputDirectories(new ProjectFacade(project)));
 	}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenAggregatingTestEventsFromMultipleCores.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/workspace/WhenAggregatingTestEventsFromMultipleCores.java
@@ -28,7 +28,6 @@
 package org.infinitest.eclipse.workspace;
 
 import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Lists.*;
 import static org.infinitest.testrunner.TestEvent.*;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
@@ -48,7 +47,7 @@ class WhenAggregatingTestEventsFromMultipleCores {
 
 	@BeforeEach
 	void inContext() {
-		events = newArrayList();
+		events = new ArrayList<>();
 		aggregator = new TestResultAggregator();
 		core = mock(InfinitestCore.class);
 	}

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/swingui/TreeModelAdapter.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/plugin/swingui/TreeModelAdapter.java
@@ -27,8 +27,7 @@
  */
 package org.infinitest.intellij.plugin.swingui;
 
-import static com.google.common.collect.Lists.newArrayList;
-
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -63,7 +62,7 @@ public class TreeModelAdapter implements TreeModel, FailureListListener, ModuleL
 
 	public TreeModelAdapter(Project project) {
 		this.project = project;
-		listeners = newArrayList();
+		listeners = new ArrayList<>();
 	}
 
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
 import static com.google.common.collect.Sets.*;
 import static java.util.logging.Level.*;
 import static org.infinitest.util.InfinitestUtils.*;
@@ -63,9 +62,9 @@ class DefaultInfinitestCore implements InfinitestCore {
 	DefaultInfinitestCore(TestRunner testRunner, EventQueue eventQueue) {
 		normalizer = new EventNormalizer(eventQueue);
 		runner = testRunner;
-		reloadListeners = newArrayList();
-		caughtExceptions = newLinkedHashSet();
-		disabledTestListeners = newArrayList();
+		reloadListeners = new ArrayList<>();
+		caughtExceptions = new LinkedHashSet<>();
+		disabledTestListeners = new ArrayList<>();
 
 		stats = new RunStatistics();
 		runner.addTestResultsListener(stats);
@@ -256,7 +255,7 @@ class DefaultInfinitestCore implements InfinitestCore {
 	}
 
 	private List<String> classesToNames(Collection<JavaClass> classes) {
-		List<String> tests = newArrayList();
+		List<String> tests = new ArrayList<>();
 		for (JavaClass javaClass : classes) {
 			tests.add(javaClass.getName());
 		}

--- a/infinitest-lib/src/main/java/org/infinitest/EventNormalizer.java
+++ b/infinitest-lib/src/main/java/org/infinitest/EventNormalizer.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Maps.*;
 import static java.lang.System.*;
 import static java.lang.reflect.Proxy.*;
 import static org.infinitest.util.InfinitestUtils.*;
@@ -102,7 +101,7 @@ class EventNormalizer {
 
 	public EventNormalizer(EventQueue eventQueue) {
 		this.eventQueue = eventQueue;
-		proxyCache = newHashMap();
+		proxyCache = new HashMap<>();
 	}
 
 	public TestQueueListener testQueueNormalizer(TestQueueListener listener) {

--- a/infinitest-lib/src/main/java/org/infinitest/QueueAggregator.java
+++ b/infinitest-lib/src/main/java/org/infinitest/QueueAggregator.java
@@ -27,8 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
 import static java.lang.Math.*;
 
 import java.util.*;
@@ -40,8 +38,8 @@ public class QueueAggregator {
 	private final List<TestQueueListener> queueListeners;
 
 	public QueueAggregator() {
-		queueListeners = newArrayList();
-		coreQueueListeners = newLinkedHashMap();
+		queueListeners = new ArrayList<>();
+		coreQueueListeners = new LinkedHashMap<>();
 	}
 
 	public void addListener(TestQueueListener testQueueAdapter) {
@@ -74,7 +72,7 @@ public class QueueAggregator {
 	}
 
 	private List<String> getAggregatedQueue() {
-		List<String> aggregatedQueue = newArrayList();
+		List<String> aggregatedQueue = new ArrayList<>();
 		for (AggregatingQueueListener each : coreQueueListeners.values()) {
 			aggregatedQueue.addAll(each.currentQueue);
 		}
@@ -100,7 +98,7 @@ public class QueueAggregator {
 	}
 
 	private class AggregatingQueueListener extends TestQueueAdapter {
-		private List<String> currentQueue = newArrayList();
+		private List<String> currentQueue = new ArrayList<>();
 
 		@Override
 		public void reloading() {

--- a/infinitest-lib/src/main/java/org/infinitest/ResultCollector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/ResultCollector.java
@@ -27,8 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
 import static java.util.Collections.*;
 import static org.infinitest.CoreStatus.*;
 import static org.infinitest.util.InfinitestUtils.*;
@@ -54,9 +52,9 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 	private final QueueAggregator queueAggregator;
 
 	public ResultCollector() {
-		resultMap = newHashMap();
-		changeListeners = newArrayList();
-		statusChangeListeners = newArrayList();
+		resultMap = new HashMap<>();
+		changeListeners = new ArrayList<>();
+		statusChangeListeners = new ArrayList<>();
 		failuresByPointOfFailure = ArrayListMultimap.create();
 		status = SCANNING;
 		queueAggregator = new QueueAggregator();
@@ -85,7 +83,7 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 	}
 
 	private List<String> findFailingTestsForCore(InfinitestCore core) {
-		List<String> tests = newArrayList();
+		List<String> tests = new ArrayList<>();
 		for (TestCaseEvent eachEvent : resultMap.values()) {
 			if (core.isEventSourceFor(eachEvent)) {
 				tests.add(eachEvent.getTestName());
@@ -127,7 +125,7 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 	}
 
 	public List<PointOfFailure> getPointsOfFailure() {
-		List<PointOfFailure> resultList = newArrayList();
+		List<PointOfFailure> resultList = new ArrayList<>();
 		for (TestEvent failure : getFailures()) {
 			PointOfFailure pointOfFailure = failure.getPointOfFailure();
 			if (!resultList.contains(pointOfFailure)) {
@@ -146,7 +144,7 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 	}
 
 	public List<TestEvent> getTestsFor(PointOfFailure pointOfFailure) {
-		List<TestEvent> matchedEvents = new ArrayList<TestEvent>();
+		List<TestEvent> matchedEvents = new ArrayList<>();
 		for (TestEvent event : getFailures()) {
 			if (event.getPointOfFailure().equals(pointOfFailure)) {
 				matchedEvents.add(event);
@@ -172,7 +170,7 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 	}
 
 	public List<TestEvent> getFailures() {
-		List<TestEvent> failures = newArrayList();
+		List<TestEvent> failures = new ArrayList<>();
 		for (TestCaseEvent each : resultMap.values()) {
 			failures.addAll(each.getFailureEvents());
 		}
@@ -229,7 +227,7 @@ public class ResultCollector implements DisabledTestListener, TestQueueListener,
 
 	@Override
 	public void reloading() {
-		List<TestEvent> failuresRemoved = newArrayList(getFailures());
+		List<TestEvent> failuresRemoved = new ArrayList<>(getFailures());
 		clear();
 		setStatus(SCANNING);
 		fireChangeEvent(noEvents(), failuresRemoved);

--- a/infinitest-lib/src/main/java/org/infinitest/TestCaseFailures.java
+++ b/infinitest-lib/src/main/java/org/infinitest/TestCaseFailures.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
 import static com.google.common.collect.Sets.*;
 
 import java.util.*;
@@ -39,8 +38,8 @@ public class TestCaseFailures {
 	private final Set<TestEvent> newFailures;
 
 	public TestCaseFailures(Collection<TestEvent> existingFailures) {
-		this.existingFailures = newHashSet(existingFailures);
-		newFailures = newHashSet();
+		this.existingFailures = new HashSet<>(existingFailures);
+		newFailures = new HashSet<>();
 	}
 
 	public void addNewFailure(TestEvent newFailure) {
@@ -54,7 +53,7 @@ public class TestCaseFailures {
 	}
 
 	public static List<TestEvent> listOf(Set<TestEventEqualityAdapter> set) {
-		ArrayList<TestEvent> list = newArrayList();
+		ArrayList<TestEvent> list = new ArrayList<>();
 		for (TestEventEqualityAdapter each : set) {
 			list.add(each.getEvent());
 		}

--- a/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
@@ -28,7 +28,6 @@
 package org.infinitest.environment;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
 import static java.io.File.pathSeparator;
 import static java.io.File.separator;
 import static java.util.logging.Level.CONFIG;
@@ -41,7 +40,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -129,13 +130,15 @@ public class RuntimeEnvironment implements ClasspathProvider {
 		this.runnerBootstrapClassPath = runnerBootstrapClassPath;
 		this.runnerProcessClassPath = runnerProcessClassPath;
 		this.projectUnderTestClassPath = projectUnderTestClassPath;
-		additionalArgs = newArrayList();
+		additionalArgs = new ArrayList<>();
 		customArgumentsReader = new FileCustomJvmArgumentReader(workingDirectory);
 	}
 
 	public List<String> createProcessArguments(ClasspathArgumentBuilder classpathArgumentBuilder) {
 		String memorySetting = "-mx" + getHeapSize() + "m";
-		List<String> args = newArrayList(getJavaExecutable(), memorySetting);
+		List<String> args = new ArrayList<>();
+		args.add(getJavaExecutable());
+		args.add(memorySetting);
 		args.addAll(additionalArgs);
 		args.addAll(classpathArgumentBuilder.buildArguments());
 		args.addAll(addCustomArguments());
@@ -143,7 +146,7 @@ public class RuntimeEnvironment implements ClasspathProvider {
 	}
 
 	public Map<String, String> createProcessEnvironment() {
-		Map<String, String> environment = newHashMap();
+		Map<String, String> environment = new HashMap<>();
 		// Put only Infinitest runner jar in classpath just to be able to load
 		// org.infinitest.testrunner.TestRunnerProcessClassLoader
 		environment.put("CLASSPATH", getRunnerBootstrapClassPath());
@@ -265,7 +268,7 @@ public class RuntimeEnvironment implements ClasspathProvider {
 		// bad set of
 		// classDirs
 		if (classDirs == null) {
-			classDirs = newArrayList();
+			classDirs = new ArrayList<>();
 			for (String each : getClasspathEntries(projectUnderTestClassPath)) {
 				File classEntry = new File(each);
 				if (classEntry.isDirectory()) {

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileIndex.java
@@ -27,13 +27,13 @@
  */
 package org.infinitest.parser;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static org.jgrapht.Graphs.predecessorListOf;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +63,7 @@ public class ClassFileIndex {
 	}
 	
 	public Set<JavaClass> removeClasses(Collection<File> removedFiles) {
-		Set<JavaClass> removedClasses = newHashSet();
+		Set<JavaClass> removedClasses = new HashSet<>();
 		
 		for (File removedFile : removedFiles) {
 			JavaClass removedClass = builder.getClass(removedFile);
@@ -78,7 +78,7 @@ public class ClassFileIndex {
 
 	public Set<JavaClass> findClasses(Collection<File> changedFiles) {
 		// First update class index
-		List<String> changedClassesNames = new ArrayList<String>();
+		List<String> changedClassesNames = new ArrayList<>();
 		for (File changedFile : changedFiles) {
 			String changedClassname = builder.classFileChanged(changedFile);
 			if (changedClassname != null) {
@@ -87,7 +87,7 @@ public class ClassFileIndex {
 		}
 
 		// Then find dependencies
-		Set<JavaClass> changedClasses = newHashSet();
+		Set<JavaClass> changedClasses = new HashSet<>();
 		for (String changedClassesName : changedClassesNames) {
 			JavaClass javaClass = builder.getClass(changedClassesName);
 			if (javaClass != null) {
@@ -172,7 +172,7 @@ public class ClassFileIndex {
 	}
 
 	public void clear() {
-		graph = new DefaultDirectedGraph<JavaClass, DefaultEdge>(DefaultEdge.class);
+		graph = new DefaultDirectedGraph<>(DefaultEdge.class);
 		classesByName.clear();
 	}
 

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.parser;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static org.infinitest.util.InfinitestUtils.log;
 
 import java.io.File;
@@ -84,7 +83,7 @@ public class ClassFileTestDetector implements TestDetector {
 	}
 
 	private Set<JavaClass> filterTests(Set<JavaClass> changedClasses) {
-		Set<JavaClass> testsToRun = new HashSet<JavaClass>();
+		Set<JavaClass> testsToRun = new HashSet<>();
 		for (JavaClass jclass : changedClasses) {
 			if (isATest(jclass) && inCurrentProject(jclass)) {
 				testsToRun.add(jclass);
@@ -134,7 +133,7 @@ public class ClassFileTestDetector implements TestDetector {
 
 	@Override
 	public Set<String> getCurrentTests() {
-		Set<String> tests = newHashSet();
+		Set<String> tests = new HashSet<>();
 		for (String each : getIndexedClasses()) {
 			if (isATest(index.findJavaClass(each))) {
 				tests.add(each);

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
@@ -46,7 +46,6 @@ import org.junit.platform.commons.annotation.Testable;
 import org.junit.runner.*;
 
 import com.google.common.base.*;
-import com.google.common.collect.*;
 
 /**
  * Be careful: instances of this class are kept in a cache
@@ -97,7 +96,7 @@ public class JavaAssistClass extends AbstractJavaClass {
 	}
 
 	private String[] findImports(CtClass ctClass) {
-		Set<String> imports = Sets.newHashSet();
+		Set<String> imports = new HashSet<>();
 		addDependenciesFromConstantPool(ctClass, imports);
 		addFieldDependencies(ctClass, imports);
 		addClassAnnotationDependencies(ctClass, imports);

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
@@ -43,8 +43,8 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.*;
 
 public class JavaAssistClassParser {
-	private final static Map<String, JavaClass> CLASSES_BY_NAME = new HashMap<>();
-	private final static Map<String, CacheEntry> BY_PATH = new HashMap<>();
+	private static final Map<String, JavaClass> CLASSES_BY_NAME = new HashMap<>();
+	private static final Map<String, CacheEntry> BY_PATH = new HashMap<>();
 	
 	private final String classpath;
 	private ClassPool classPool;

--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClassParser.java
@@ -39,11 +39,13 @@ import javassist.*;
 
 import org.infinitest.*;
 
-import com.google.common.collect.*;
 import com.google.common.hash.Hashing;
 import com.google.common.io.*;
 
 public class JavaAssistClassParser {
+	private final static Map<String, JavaClass> CLASSES_BY_NAME = new HashMap<>();
+	private final static Map<String, CacheEntry> BY_PATH = new HashMap<>();
+	
 	private final String classpath;
 	private ClassPool classPool;
 
@@ -90,8 +92,6 @@ public class JavaAssistClassParser {
 		return !new File(iter.next()).exists();
 	}
 
-	private final static Map<String, JavaClass> CLASSES_BY_NAME = Maps.newHashMap();
-
 	public JavaClass getClass(String className) {
 		JavaClass clazz = CLASSES_BY_NAME.get(className);
 		if (clazz == null) {
@@ -117,8 +117,6 @@ public class JavaAssistClassParser {
 
 		return clazz;
 	}
-
-	private final static Map<String, CacheEntry> BY_PATH = Maps.newHashMap();
 
 	public static class CacheEntry {
 		final String sha1;

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/AbstractTestRunner.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/AbstractTestRunner.java
@@ -27,7 +27,7 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Lists.*;
+import static java.util.Collections.singletonList;
 
 import java.util.*;
 
@@ -101,7 +101,7 @@ public abstract class AbstractTestRunner implements TestRunner {
 	}
 
 	public void runTest(String testClass) {
-		runTests(newArrayList(testClass));
+		runTests(singletonList(testClass));
 	}
 
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/RunStatistics.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/RunStatistics.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Maps.*;
 import static java.lang.System.*;
 
 import java.util.*;
@@ -36,7 +35,7 @@ public class RunStatistics implements TestResultsListener {
 	private final Map<String, Long> failureTimestamps;
 
 	public RunStatistics() {
-		failureTimestamps = newHashMap();
+		failureTimestamps = new HashMap<>();
 	}
 
 	private void update(TestEvent event) {

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/RunnerEventSupport.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/RunnerEventSupport.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Lists.*;
 import static org.infinitest.testrunner.TestEvent.*;
 
 import java.util.*;
@@ -43,9 +42,9 @@ public class RunnerEventSupport {
 
 	public RunnerEventSupport(Object eventSource) {
 		source = eventSource;
-		listeners = newArrayList();
-		consoleListenerList = newArrayList();
-		testQueueListenerList = newArrayList();
+		listeners = new ArrayList<>();
+		consoleListenerList = new ArrayList<>();
+		testQueueListenerList = new ArrayList<>();
 	}
 
 	public void addTestStatusListener(TestResultsListener listener) {

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/TestCaseEvent.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/TestCaseEvent.java
@@ -27,9 +27,9 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.unmodifiableList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -43,7 +43,7 @@ public class TestCaseEvent {
 		this.testName = testName;
 		this.source = source;
 		this.results = results;
-		methodEvents = newArrayList();
+		methodEvents = new ArrayList<>();
 		// DEBT move this to a static factory method?
 		for (TestEvent testEvent : results) {
 			if (!isCompilationErrors(testEvent)) {

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/queue/ProcessorRunnable.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/queue/ProcessorRunnable.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.testrunner.queue;
 
-import static com.google.common.collect.Lists.*;
 import static org.infinitest.util.InfinitestUtils.*;
 
 import java.util.*;
@@ -55,7 +54,7 @@ class ProcessorRunnable implements Runnable {
 	}
 
 	private void fireEvent() {
-		eventSupport.fireQueueEvent(new TestQueueEvent(newArrayList(testQueue), initialSize));
+		eventSupport.fireQueueEvent(new TestQueueEvent(new ArrayList<>(testQueue), initialSize));
 	}
 
 	@Override

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/queue/QueueConsumer.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/queue/QueueConsumer.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.testrunner.queue;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.concurrent.Executors.*;
 
 import java.io.*;
@@ -93,7 +92,7 @@ public abstract class QueueConsumer {
 
 		private void startNewTestRun() {
 			processorThread = new QueueProcessorThread(runnable);
-			eventSupport.fireQueueEvent(new TestQueueEvent(newArrayList(testQueue), testQueue.size()));
+			eventSupport.fireQueueEvent(new TestQueueEvent(new ArrayList<>(testQueue), testQueue.size()));
 			processorThread.start();
 		}
 

--- a/infinitest-lib/src/main/java/org/infinitest/util/Events.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/Events.java
@@ -27,14 +27,12 @@
  */
 package org.infinitest.util;
 
-import static com.google.common.collect.Lists.*;
-
 import java.lang.reflect.*;
 import java.util.*;
 
 public class Events<T> {
 	private final Method eventMethod;
-	private final List<T> listeners = newArrayList();
+	private final List<T> listeners = new ArrayList<>();
 
 	public Events(Method eventMethod) {
 		this.eventMethod = eventMethod;
@@ -62,6 +60,6 @@ public class Events<T> {
 
 	public static <T> Events<T> eventFor(Class<T> listenerClass) {
 		Method method = listenerClass.getDeclaredMethods()[0];
-		return new Events<T>(method);
+		return new Events<>(method);
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/util/InfinitestUtils.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/InfinitestUtils.java
@@ -50,7 +50,7 @@ import org.apache.commons.lang.SystemUtils;
  * @author <a href="mailto:benrady@gmail.com"Ben Rady</a>
  */
 public class InfinitestUtils {
-	private static List<LoggingListener> loggingListeners = new ArrayList<LoggingListener>();
+	private static List<LoggingListener> loggingListeners = new ArrayList<>();
 
 	private static final String LINE_SEP = "\n";
 	private static final int MAX_LINE_COUNT = 50;
@@ -66,7 +66,7 @@ public class InfinitestUtils {
 	}
 
 	public static <T> Set<T> setify(T... items) {
-		Set<T> set = new HashSet<T>();
+		Set<T> set = new HashSet<>();
 		set.addAll(asList(items));
 		return set;
 	}
@@ -109,7 +109,7 @@ public class InfinitestUtils {
 	}
 
 	public static List<String> getClassNames(StackTraceElement[] currentStack) {
-		ArrayList<String> list = new ArrayList<String>();
+		ArrayList<String> list = new ArrayList<>();
 		for (StackTraceElement element : currentStack) {
 			list.add(element.getClassName());
 		}

--- a/infinitest-lib/src/main/java/org/infinitest/util/TestClass.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/TestClass.java
@@ -44,7 +44,7 @@ class TestClass {
 	}
 
 	public List<Method> getAnnotatedMethods(Class<? extends Annotation> annotationClass) {
-		List<Method> results = new ArrayList<Method>();
+		List<Method> results = new ArrayList<>();
 		for (Class<?> eachClass : getSuperClasses(fClass)) {
 			Method[] methods = eachClass.getDeclaredMethods();
 			for (Method eachMethod : methods) {
@@ -89,7 +89,7 @@ class TestClass {
 	}
 
 	private List<Class<?>> getSuperClasses(Class<?> testClass) {
-		ArrayList<Class<?>> results = new ArrayList<Class<?>>();
+		ArrayList<Class<?>> results = new ArrayList<>();
 		Class<?> current = testClass;
 		while (current != null) {
 			results.add(current);

--- a/infinitest-lib/src/test/java/org/infinitest/ControlledEventQueue.java
+++ b/infinitest-lib/src/test/java/org/infinitest/ControlledEventQueue.java
@@ -27,12 +27,10 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-
 import java.util.*;
 
 public class ControlledEventQueue implements EventQueue {
-	private final List<Runnable> events = newArrayList();
+	private final List<Runnable> events = new ArrayList<>();
 
 	@Override
 	public synchronized void push(Runnable runnable) {
@@ -41,7 +39,7 @@ public class ControlledEventQueue implements EventQueue {
 
 	public synchronized void flush() {
 		// We make a copy because some event handlers fire new events
-		ArrayList<Runnable> eventsToFire = newArrayList(events);
+		List<Runnable> eventsToFire = new ArrayList<>(events);
 		events.clear();
 		for (Runnable event : eventsToFire) {
 			event.run();

--- a/infinitest-lib/src/test/java/org/infinitest/EventSupport.java
+++ b/infinitest-lib/src/test/java/org/infinitest/EventSupport.java
@@ -28,9 +28,6 @@
 package org.infinitest;
 
 import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
-import static com.google.common.collect.Sets.*;
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.infinitest.testrunner.TestEvent.*;
@@ -55,10 +52,10 @@ public class EventSupport implements StatusChangeListener, TestQueueListener, Te
 	private int reloadCount;
 
 	public EventSupport(long timeout) {
-		testCaseEvents = newHashMap();
-		testEvents = newArrayList();
-		propertyEvents = newArrayList();
-		queueEvents = newArrayList();
+		testCaseEvents = new HashMap<>();
+		testEvents = new ArrayList<>();
+		propertyEvents = new ArrayList<>();
+		queueEvents = new ArrayList<>();
 		runComplete = new ThreadSafeFlag(timeout);
 		reload = new ThreadSafeFlag(timeout);
 		this.timeout = timeout;
@@ -180,7 +177,7 @@ public class EventSupport implements StatusChangeListener, TestQueueListener, Te
 	}
 
 	public Iterable<String> getTestsRun() {
-		Set<String> tests = newHashSet();
+		Set<String> tests = new HashSet<>();
 		for (TestEvent event : testEvents) {
 			tests.add(event.getTestName());
 		}
@@ -216,7 +213,7 @@ public class EventSupport implements StatusChangeListener, TestQueueListener, Te
 	}
 
 	public void assertTestsStarted(Class<?>... classes) {
-		List<String> testNames = newArrayList();
+		List<String> testNames = new ArrayList<>();
 		for (Class<?> each : classes) {
 			testNames.add(each.getName());
 		}

--- a/infinitest-lib/src/test/java/org/infinitest/FailureListenerSupport.java
+++ b/infinitest-lib/src/test/java/org/infinitest/FailureListenerSupport.java
@@ -27,8 +27,6 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Lists.*;
-
 import java.util.*;
 
 import org.infinitest.testrunner.*;
@@ -40,10 +38,10 @@ class FailureListenerSupport implements FailureListListener {
 	public final List<TestEvent> changed;
 
 	FailureListenerSupport() {
-		added = newArrayList();
-		removed = newArrayList();
-		failures = newArrayList();
-		changed = newArrayList();
+		added = new ArrayList<>();
+		removed = new ArrayList<>();
+		failures = new ArrayList<>();
+		changed = new ArrayList<>();
 	}
 
 	@Override

--- a/infinitest-lib/src/test/java/org/infinitest/WhenAggregatingTestQueues.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenAggregatingTestQueues.java
@@ -28,11 +28,11 @@
 package org.infinitest;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,9 +48,9 @@ class WhenAggregatingTestQueues {
 	@BeforeEach
 	void inContext() {
 		ResultCollector collector = new ResultCollector();
-		updateEvents = newArrayList();
+		updateEvents = new ArrayList<>();
 		finishCount = new AtomicInteger();
-		listeners = newArrayList();
+		listeners = new ArrayList<>();
 		collector.addTestQueueListener(new TestQueueAdapter() {
 			@Override
 			public void testQueueUpdated(TestQueueEvent event) {

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTestsAreDisabled.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTestsAreDisabled.java
@@ -28,7 +28,6 @@
 package org.infinitest;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.collect.Sets.newHashSet;
 import static org.infinitest.CoreDependencySupport.withChangedFiles;
 import static org.infinitest.util.InfinitestUtils.setify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.infinitest.parser.JavaClass;
@@ -60,7 +60,7 @@ class WhenTestsAreDisabled {
 		DefaultInfinitestCore core = new DefaultInfinitestCore(runner, new ControlledEventQueue());
 		core.setChangeDetector(withChangedFiles(PassingTest.class));
 		core.setTestDetector(testDetector);
-		final Set<String> disabledTestList = newHashSet();
+		final Set<String> disabledTestList = new HashSet<>();
 		core.addDisabledTestListener(new DisabledTestListener() {
 			@Override
 			public void testsDisabled(Collection<String> testName) {

--- a/infinitest-lib/src/test/java/org/infinitest/WhenTestsResultsAreProcessed.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenTestsResultsAreProcessed.java
@@ -40,13 +40,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import org.infinitest.testrunner.TestEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Lists;
 
 class WhenTestsResultsAreProcessed extends ResultCollectorTestSupport {
 	private EventSupport statusListener;
@@ -116,7 +115,7 @@ class WhenTestsResultsAreProcessed extends ResultCollectorTestSupport {
 		testRunWith(testName, methodFailed(testName, "someMethod", new NullPointerException()));
 		assertEquals(1, collector.getFailures().size());
 
-		final Collection<TestEvent> removed = Lists.newArrayList();
+		final Collection<TestEvent> removed = new ArrayList<>();
 		collector.addChangeListener(new FailureListListener() {
 			@Override
 			public void failureListChanged(Collection<TestEvent> failuresAdded, Collection<TestEvent> failuresRemoved) {

--- a/infinitest-lib/src/test/java/org/infinitest/environment/FileCustomJvmArgumentReaderTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/environment/FileCustomJvmArgumentReaderTest.java
@@ -28,8 +28,9 @@
 package org.infinitest.environment;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.Files.write;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.infinitest.environment.FileCustomJvmArgumentReader.FILE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -92,7 +93,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList(singleArgument), arguments);
+		assertEquals(singletonList(singleArgument), arguments);
 	}
 	
 	@Test
@@ -101,7 +102,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
+		assertEquals(asList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
 	}
 	
 	@Test
@@ -110,7 +111,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList("-DsomeArg=\"hello world\"", "-DanotherArg=foo"), arguments);
+		assertEquals(asList("-DsomeArg=\"hello world\"", "-DanotherArg=foo"), arguments);
 	}
 	
 	@Test
@@ -119,7 +120,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
+		assertEquals(asList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
 	}
 
 	
@@ -129,7 +130,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
+		assertEquals(asList("-DsomeArg=foo", "-DanotherArg=foo"), arguments);
 	}
 	
 	@Test
@@ -138,7 +139,7 @@ class FileCustomJvmArgumentReaderTest {
 
 		List<String> arguments = reader.readCustomArguments();
 
-		assertEquals(newArrayList("-DsomeArg=foo not another Arg"), arguments);
+		assertEquals(asList("-DsomeArg=foo not another Arg"), arguments);
 	}
 
 

--- a/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
@@ -28,7 +28,6 @@
 package org.infinitest.environment;
 
 import static com.google.common.collect.Iterables.get;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.Files.touch;
 import static java.util.Arrays.asList;
 import static java.util.logging.Level.WARNING;
@@ -221,7 +220,7 @@ class RuntimeEnvironmentTest {
 
 	private RuntimeEnvironment createEnv(String outputDir, String workingDir, String classpath, String javahome) {
 		RuntimeEnvironment env = new RuntimeEnvironment(new File(javahome), new File(workingDir),
-				"runnerClassLoaderClassPath", "runnerProcessClassPath", newArrayList(new File(outputDir)), classpath);
+				"runnerClassLoaderClassPath", "runnerProcessClassPath", asList(new File(outputDir)), classpath);
 		return env;
 	}
 

--- a/infinitest-lib/src/test/java/org/infinitest/parser/LargeWorkspacePerformanceSimulation.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/LargeWorkspacePerformanceSimulation.java
@@ -27,12 +27,12 @@
  */
 package org.infinitest.parser;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.infinitest.environment.FakeEnvironments.fakeClasspath;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -51,8 +51,8 @@ class LargeWorkspacePerformanceSimulation {
   void inContext() throws IOException {
     FileChangeDetector detector = new FileChangeDetector();
     detector.setClasspathProvider(fakeClasspath());
-    indexes = newArrayList();
-    files = newArrayList(detector.findChangedFiles());
+    indexes = new ArrayList<>();
+    files = new ArrayList<>(detector.findChangedFiles());
   }
 
   public static void main(String[] args) throws IOException {

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/TestCaseEventTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/TestCaseEventTest.java
@@ -27,11 +27,11 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.infinitest.testrunner.TestEvent.methodFailed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.infinitest.util.EqualityTestSupport;
@@ -45,7 +45,7 @@ class TestCaseEventTest extends EqualityTestSupport {
 
 	@BeforeEach
 	void inContext() {
-		methodEvents = newArrayList();
+		methodEvents = new ArrayList<>();
 		source = "";
 		event = new TestCaseEvent("testName", source, new TestResults(methodEvents));
 	}

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/TestRunnerEventSupport.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/TestRunnerEventSupport.java
@@ -27,11 +27,11 @@
  */
 package org.infinitest.testrunner;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.infinitest.TestQueueAdapter;
@@ -62,7 +62,7 @@ class TestRunnerEventSupport {
 
   @Test
   void shouldFireTestQueueEvents() {
-    final List<TestQueueEvent> queueEvents = newArrayList();
+    final List<TestQueueEvent> queueEvents = new ArrayList<>();
     eventSupport.addTestQueueListener(new TestQueueAdapter() {
       @Override
       public void testQueueUpdated(TestQueueEvent event) {

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/process/WhenCreatingRunnerProcessConnection.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/process/WhenCreatingRunnerProcessConnection.java
@@ -38,6 +38,7 @@ import java.io.PrintStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.infinitest.environment.ClasspathArgumentBuilder;
@@ -48,8 +49,6 @@ import org.infinitest.testrunner.TestEvent;
 import org.infinitest.testrunner.TestResults;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Lists;
 
 class WhenCreatingRunnerProcessConnection {
 	private NativeConnectionFactory factory;
@@ -86,7 +85,7 @@ class WhenCreatingRunnerProcessConnection {
 			Socket socket = serverSocket.accept();
 			ObjectInputStream inStream = new ObjectInputStream(socket.getInputStream());
 			PrintStream outStream = new PrintStream(socket.getOutputStream(), true, "UTF-8");
-			List<TestEvent> results = Lists.newArrayList();
+			List<TestEvent> results = new ArrayList<>();
 			TestResults result = null;
 			int i = 0;
 			do {

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/queue/QueueConsumerTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/queue/QueueConsumerTest.java
@@ -28,12 +28,12 @@
 package org.infinitest.testrunner.queue;
 
 import static com.google.common.collect.Iterables.get;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -59,7 +59,7 @@ class QueueConsumerTest {
 		processSemaphore = null;
 		events = new SynchronousQueue<String>(true);
 		runnerEvents = new RunnerEventSupport(this);
-		queueUpdates = newArrayList();
+		queueUpdates = new ArrayList<>();
 		queue = new QueueConsumer(runnerEvents, new LinkedList<String>()) {
 			@Override
 			protected QueueProcessor createQueueProcessor() {

--- a/infinitest-lib/src/test/java/org/infinitest/util/WhenLoggingMessagesAndErrors.java
+++ b/infinitest-lib/src/test/java/org/infinitest/util/WhenLoggingMessagesAndErrors.java
@@ -27,7 +27,6 @@
  */
 package org.infinitest.util;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.infinitest.util.InfinitestGlobalSettings.getLogLevel;
 import static org.infinitest.util.InfinitestGlobalSettings.setLogLevel;
 import static org.infinitest.util.InfinitestUtils.addLoggingListener;
@@ -35,6 +34,7 @@ import static org.infinitest.util.InfinitestUtils.log;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -49,8 +49,8 @@ class WhenLoggingMessagesAndErrors implements LoggingListener {
 
 	@BeforeEach
 	void inContext() {
-		errors = newHashMap();
-		messages = newHashMap();
+		errors = new HashMap<>();
+		messages = new HashMap<>();
 		addLoggingListener(this);
 		oldLevel = getLogLevel();
 	}

--- a/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
+++ b/infinitest-runner/src/main/java/org/infinitest/TestNGConfigurator.java
@@ -60,7 +60,7 @@ public class TestNGConfigurator {
 	}
 
 	private List<Object> createListenerList(ImmutableSet<String> listenerClassNames) {
-		List<Object> listenerList = new ArrayList<Object>();
+		List<Object> listenerList = new ArrayList<>();
 
 		for (String listenerClassName : listenerClassNames) {
 			try {

--- a/infinitest-runner/src/main/java/org/infinitest/config/InfinitestConfigurationParser.java
+++ b/infinitest-runner/src/main/java/org/infinitest/config/InfinitestConfigurationParser.java
@@ -100,11 +100,11 @@ public class InfinitestConfigurationParser {
 
 	public InfinitestConfiguration parseFileContent(CharSource textConfiguration) throws IOException {
 
-		List<String> excludedPatterns = new ArrayList<String>();
-		List<String> includedPatterns = new ArrayList<String>();
-		List<String> includedGroups = new ArrayList<String>();
-		List<String> excludedGroups = new ArrayList<String>();
-		List<String> testngListeners = new ArrayList<String>();
+		List<String> excludedPatterns = new ArrayList<>();
+		List<String> includedPatterns = new ArrayList<>();
+		List<String> includedGroups = new ArrayList<>();
+		List<String> excludedGroups = new ArrayList<>();
+		List<String> testngListeners = new ArrayList<>();
 
 		// Be careful the order of the parsers below is important as the lousy
 		// parsers are put at the end

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/TestResults.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/TestResults.java
@@ -36,7 +36,7 @@ public class TestResults implements Iterable<TestEvent>, Serializable {
 	private static final long serialVersionUID = 1612875588926016329L;
 
 	private final List<TestEvent> eventsCollected;
-	private final List<MethodStats> methodStats = new LinkedList<MethodStats>();
+	private final List<MethodStats> methodStats = new LinkedList<>();
 
 	public TestResults(List<TestEvent> eventsCollected) {
 		this.eventsCollected = eventsCollected;

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/junit4/JUnitEventTranslator.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/junit4/JUnitEventTranslator.java
@@ -49,8 +49,8 @@ class JUnitEventTranslator extends RunListener {
 
 	JUnitEventTranslator(Clock clock) {
 		this.clock = clock;
-		eventsCollected = new ArrayList<TestEvent>();
-		methodStats = new HashMap<Description, MethodStats>();
+		eventsCollected = new ArrayList<>();
+		methodStats = new HashMap<>();
 	}
 
 	JUnitEventTranslator() {

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/junit4/Junit4And3Runner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/junit4/Junit4And3Runner.java
@@ -103,7 +103,7 @@ public class Junit4And3Runner {
 	private Class<?>[] readExcludedGroupsFromConfiguration() {
 		InfinitestConfiguration configuration = configSource.getConfiguration();
 
-		List<Class<?>> categoriesToExclude = new ArrayList<Class<?>>();
+		List<Class<?>> categoriesToExclude = new ArrayList<>();
 		for (String excludedGroup : configuration.excludedGroups()) {
 			try {
 				categoriesToExclude.add(Class.forName(excludedGroup));

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/junit5/JUnit5EventTranslator.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/junit5/JUnit5EventTranslator.java
@@ -57,8 +57,8 @@ class JUnit5EventTranslator implements TestExecutionListener {
 	
 	public JUnit5EventTranslator(Clock clock) {
 		this.clock = clock;
-		eventsCollected = new ArrayList<TestEvent>();
-		methodStats = new HashMap<TestIdentifier, MethodStats>();
+		eventsCollected = new ArrayList<>();
+		methodStats = new HashMap<>();
 	}
 
 	@Override

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/testng/TestNgRunner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/testng/TestNgRunner.java
@@ -95,7 +95,7 @@ public class TestNgRunner {
 	}
 	
 	private static class TestNGEventTranslator implements ITestListener {
-		private final List<TestEvent> events = new ArrayList<TestEvent>();
+		private final List<TestEvent> events = new ArrayList<>();
 
 		@Override
 		public void onTestFailure(ITestResult failure) {


### PR DESCRIPTION
Now that Java has the diamond operator there's really no need to use Guava's newArrayList, newHashSet or newHashMap