### PR TITLE
Symlink handling

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -31,6 +31,7 @@ import static java.io.File.pathSeparator;
 import static org.infinitest.util.InfinitestUtils.log;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,8 +126,16 @@ public class IdeaModuleSettings implements ModuleSettings {
 
     private void addOutputDirectory(List<File> outputDirectories, String path) {
         if (path != null) {
-            log(java.util.logging.Level.FINE, "Adding output directory: " + path);
-            outputDirectories.add(new File(path));
+        	File file = new File(path);
+        	
+        	try {
+        		log(java.util.logging.Level.FINE, "Adding output directory: " + path);
+				File canonicalFile = file.getCanonicalFile();
+        		outputDirectories.add(canonicalFile);
+        	} catch (IOException e) {
+        		log("Error while getting canonical file for: " + path, e);
+        		outputDirectories.add(file);
+			}
         }
     }
 

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -111,33 +111,33 @@ public class IdeaModuleSettings implements ModuleSettings {
 	 * 
 	 * @return A list of all of the output directories for the project
 	 */
-    private List<File> listOutputDirectories() {
-        List<File> outputDirectories = new ArrayList<File>();
+	private List<File> listOutputDirectories() {
+		List<File> outputDirectories = new ArrayList<File>();
 
-        addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, TEST_CLASSES));
-        addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, MAIN_CLASSES));
-        ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-        for (Module dependantModule : moduleRootManager.getDependencies()) {
-            addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(dependantModule, MAIN_CLASSES));
-        }
+		addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, TEST_CLASSES));
+		addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, MAIN_CLASSES));
+		ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+		for (Module dependantModule : moduleRootManager.getDependencies()) {
+			addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(dependantModule, MAIN_CLASSES));
+		}
 
-        return outputDirectories;
-    }
+		return outputDirectories;
+	}
 
-    private void addOutputDirectory(List<File> outputDirectories, String path) {
-        if (path != null) {
-        	File file = new File(path);
-        	
-        	try {
-        		log(java.util.logging.Level.FINE, "Adding output directory: " + path);
+	private void addOutputDirectory(List<File> outputDirectories, String path) {
+		if (path != null) {
+			File file = new File(path);
+
+			try {
+				log(java.util.logging.Level.FINE, "Adding output directory: " + path);
 				File canonicalFile = file.getCanonicalFile();
-        		outputDirectories.add(canonicalFile);
-        	} catch (IOException e) {
-        		log("Error while getting canonical file for: " + path, e);
-        		outputDirectories.add(file);
+				outputDirectories.add(canonicalFile);
+			} catch (IOException e) {
+				log("Error while getting canonical file for: " + path, e);
+				outputDirectories.add(file);
 			}
-        }
-    }
+		}
+	}
 
 
 	/**

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -111,8 +111,8 @@ public class IdeaModuleSettings implements ModuleSettings {
 	 * 
 	 * @return A list of all of the output directories for the project
 	 */
-	private List<File> listOutputDirectories() {
-		List<File> outputDirectories = new ArrayList<File>();
+	protected List<File> listOutputDirectories() {
+		List<File> outputDirectories = new ArrayList<>();
 
 		addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, TEST_CLASSES));
 		addOutputDirectory(outputDirectories, CompilerPaths.getModuleOutputPath(module, MAIN_CLASSES));

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -37,7 +37,6 @@ import org.infinitest.FailureListListener;
 import org.infinitest.StatusChangeListener;
 import org.infinitest.TestQueueListener;
 import org.infinitest.intellij.idea.IdeaLogService;
-import org.infinitest.intellij.idea.LogService;
 import org.infinitest.intellij.idea.LogServiceState;
 import org.infinitest.intellij.idea.ProjectTestControl;
 import org.infinitest.intellij.plugin.launcher.InfinitestLauncher;
@@ -54,6 +53,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
@@ -147,6 +147,18 @@ public class IntellijMockBase {
 		logService.loadState(logServiceState);
 		
 		when(application.getService(IdeaLogService.class)).thenReturn(logService);
+		
+		// Read actions
+		
+		try {
+			when(application.runReadAction((ThrowableComputable<?,?>) any())).then(i -> {
+				ThrowableComputable<?,?> computable = i.getArgument(0, ThrowableComputable.class);
+				
+				return computable.compute();
+			});
+		} catch (Throwable e) {
+			throw new IllegalStateException("Could not mock actions", e);
+		}
 		
 		ApplicationManager.setApplication(application, parent);
 		

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaModuleSettingsTest.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaModuleSettingsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.intellij.idea;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.List;
+
+import org.infinitest.intellij.IntellijMockBase;
+import org.junit.jupiter.api.Test;
+
+import com.intellij.openapi.roots.CompilerModuleExtension;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.module.Module;
+
+class IdeaModuleSettingsTest extends IntellijMockBase {
+
+	@Test
+	void listOutputDirectories() {
+		setupApplication();
+		
+		ModuleRootManager rootManager = mock(ModuleRootManager.class);
+		CompilerModuleExtension compilerModuleExtension = mock(CompilerModuleExtension.class);
+		
+		when(module.getComponent(ModuleRootManager.class)).thenReturn(rootManager);
+		when(rootManager.getDependencies()).thenReturn(new Module[0]);
+		when(rootManager.getModuleExtension(CompilerModuleExtension.class)).thenReturn(compilerModuleExtension);
+		when(compilerModuleExtension.getCompilerOutputUrl()).thenReturn("/project/target/classes");
+		when(compilerModuleExtension.getCompilerOutputUrlForTests()).thenReturn("/project/target/test-classes");
+		IdeaModuleSettings settings = new IdeaModuleSettings(module);
+		
+		List<File> outputDirs = settings.listOutputDirectories();
+		
+		assertThat(outputDirs).hasSize(2);
+	}
+
+}


### PR DESCRIPTION
ClassFileTestDetector.inCurrentProject() checks if the class file path is prefixed by one of the class output dirs, however the path of the class is its canonical path (symbolic converted) while the class output dir is not.
Convert the class output dirs to their canonical paths so we can test if the classes are in these dirs