### PR TITLE
fix: detect methods annotated with ArchTest as ArchUnit tests

### DIFF
--- a/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/JavaAssistClass.java
@@ -67,6 +67,8 @@ import junit.framework.TestCase;
  * so we should keep its footprint minimal.
  */
 public class JavaAssistClass extends AbstractJavaClass {
+	private static final String ARCHUNIT_ARCHTEST = "com.tngtech.archunit.junit.ArchTest";
+	
 	private final String[] imports;
 	private final boolean isATest;
 	private final String className;
@@ -299,7 +301,14 @@ public class JavaAssistClass extends AbstractJavaClass {
 
 	private boolean hasArchUnitTests(CtClass classReference) {
 		for (CtField field : classReference.getDeclaredFields()) {
-			if (field.hasAnnotation("com.tngtech.archunit.junit.ArchTest")) {
+			if (field.hasAnnotation(ARCHUNIT_ARCHTEST)) {
+				return true;
+			}
+		}
+		
+		// getMethods() returns the non-private methods
+		for (CtMethod ctMethod : classReference.getDeclaredMethods()) {
+			if (ctMethod.hasAnnotation(ARCHUNIT_ARCHTEST)) {
 				return true;
 			}
 		}

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ArchUnitMethodTest.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ArchUnitMethodTest.java
@@ -36,10 +36,6 @@ import com.tngtech.archunit.junit.ArchTest;
 @AnalyzeClasses(packages = "com.fakeco.fakeproduct")
 public class JUnit5ArchUnitMethodTest {
 	
-	public void test() {
-		no_access_to_standard_streams_as_method();
-	}
-
 	@ArchTest
 	private void no_access_to_standard_streams_as_method() {
 		noClasses().should(ACCESS_STANDARD_STREAMS);

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ArchUnitMethodTest.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/JUnit5ArchUnitMethodTest.java
@@ -27,15 +27,21 @@
  */
 package com.fakeco.fakeproduct;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.GeneralCodingRules.ACCESS_STANDARD_STREAMS;
+
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
-
-import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
 @AnalyzeClasses(packages = "com.fakeco.fakeproduct")
-public class JUnit5ArchUnitTest {
+public class JUnit5ArchUnitMethodTest {
+	
+	public void test() {
+		no_access_to_standard_streams_as_method();
+	}
 
 	@ArchTest
-	private final ArchRule no_access_to_standard_streams = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+	private void no_access_to_standard_streams_as_method() {
+		noClasses().should(ACCESS_STANDARD_STREAMS);
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTest.java
@@ -52,6 +52,7 @@ import com.fakeco.fakeproduct.FakeUtils;
 import com.fakeco.fakeproduct.FieldAnnotation;
 import com.fakeco.fakeproduct.InvisibleClassAnnotation;
 import com.fakeco.fakeproduct.InvisibleParameterAnnotation;
+import com.fakeco.fakeproduct.JUnit5ArchUnitMethodTest;
 import com.fakeco.fakeproduct.JUnit5ArchUnitTest;
 import com.fakeco.fakeproduct.JUnit5CompositeAnnotationTest;
 import com.fakeco.fakeproduct.JUnit5ParameterizedTest;
@@ -159,6 +160,7 @@ class JavaAssistClassTest {
 			JUnit5Testable.class,
 			JUnit5TestableSubclass.class,
 			JUnit5ArchUnitTest.class,
+			JUnit5ArchUnitMethodTest.class,
 	})
 	void shouldSupportTestClasses(Class<?> testClass) throws NotFoundException {
 		ClassPool classPool = classPoolUtil.getClassPool();


### PR DESCRIPTION
ArchUnit tests can be declared as fields or as methods: also check for methods. Added missing AnalyzeClasses annotation on sample test