### PR TITLE
build: exclude unnecessary intellij dependecies

### DIFF
--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <intellij.version>20.1.0</intellij.version>
     <intellij.api.version>221.5787.30</intellij.api.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
   </properties>
@@ -95,6 +96,12 @@
       <version>${guava.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>${intellij.version}</version>
@@ -117,12 +124,35 @@
       <artifactId>lang-core</artifactId>
       <version>${intellij.api.version}</version>
       <scope>provided</scope>
+      <!-- Exclude some unnecessary transitive dependencies to reduce the data downloaded -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>ide-core-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>usage-view</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jetbrains.intellij.platform</groupId>
       <artifactId>util</artifactId>
       <version>${intellij.api.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jetbrains.intellij.platform</groupId>
+      <artifactId>execution-impl</artifactId>
+      <version>${intellij.api.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.jetbrains.intellij.java</groupId>
@@ -146,6 +176,52 @@
         <exclusion>
           <groupId>org.apache.ws.xmlrpc</groupId>
           <artifactId>xmlrpc</artifactId>
+        </exclusion>
+        
+        <!-- Exclude some unnecessary transitive dependencies to reduce the data downloaded -->
+        <exclusion>
+          <groupId>com.jetbrains.intellij.java</groupId>
+          <artifactId>java-analysis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>ide-core-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>usage-view</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>external-system</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.xml</groupId>
+          <artifactId>xml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>statistics</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>vcs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>project-model-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>workspace-model-storage</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>indexing-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jetbrains.intellij.platform</groupId>
+          <artifactId>remote-core</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Donwloading all the transitive IntelliJ dependencies takes a very long time on the Github builds, remove some dependencies that we don't seem to need.

The (possibly non exhaustive) list of dependencies we currently need is: 

- execution-impl
- core
- analysis-impl
- editor
- util
- util-ui
- lang
- project-model
- extensions
- java-compiler
- java-psi
- ide
- analysis-impl