### PR TITLE
fix: we shouldn't run tests on a module with no JDK

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/ProjectTestControl.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/ProjectTestControl.java
@@ -29,6 +29,8 @@ package org.infinitest.intellij.idea;
 
 import org.infinitest.InfinitestCore;
 import org.infinitest.TestControl;
+import org.infinitest.environment.RuntimeEnvironment;
+import org.infinitest.intellij.ModuleSettings;
 import org.infinitest.intellij.plugin.launcher.InfinitestLauncher;
 
 import com.intellij.ide.PowerSaveMode;
@@ -97,14 +99,27 @@ public final class ProjectTestControl implements TestControl, PersistentStateCom
 
 	@Override
 	public boolean shouldRunTests(Module module) {
-		return !state.getDisabledModulesNames().contains(module.getName()) && !PowerSaveMode.isEnabled();
+		return !state.getDisabledModulesNames().contains(module.getName()) 
+				&& !PowerSaveMode.isEnabled()
+				&& moduleHasRuntimeEnvironment(module);
 	}
 	
+	/**
+	 * In case a module does not have a JDK (for instance a Javascript module) it won't have a JDK
+	 * @param module The module
+	 * @return <code>true</code> if the module has a {@link RuntimeEnvironment} we can use to run tests
+	 */
+	private boolean moduleHasRuntimeEnvironment(Module module) {
+		ModuleSettings moduleSettings = module.getService(ModuleSettings.class);
+		return moduleSettings.getRuntimeEnvironment() != null;
+	}
+
 	@Override
 	public boolean shouldRunTests() {
 		return state.isRunTests();
 	}
 	
+	@Override
 	public void loadState(ProjectTestControlState state) {
 		this.state = state;
 	}

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -36,6 +36,7 @@ import org.infinitest.DisabledTestListener;
 import org.infinitest.FailureListListener;
 import org.infinitest.StatusChangeListener;
 import org.infinitest.TestQueueListener;
+import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.intellij.idea.IdeaLogService;
 import org.infinitest.intellij.idea.LogServiceState;
 import org.infinitest.intellij.idea.ProjectTestControl;
@@ -72,6 +73,8 @@ public class IntellijMockBase {
 	protected MessageBusConnection messageBusConnection;
 	
 	protected InfinitestLauncher launcher;
+	protected ModuleSettings moduleSettings;
+	protected RuntimeEnvironment runtimeEnvironment;
 	protected ProjectTestControl control;
 	protected InfinitestAnnotator annotator;
 	
@@ -83,6 +86,8 @@ public class IntellijMockBase {
 		messageBus = mock(MessageBus.class);
 		messageBusConnection = mock(MessageBusConnection.class);
 		launcher = mock(InfinitestLauncher.class);
+		moduleSettings = mock(ModuleSettings.class);
+		runtimeEnvironment = mock(RuntimeEnvironment.class);
 		control = new ProjectTestControl(project);
 		annotator = mock(InfinitestAnnotator.class);
 		
@@ -94,6 +99,9 @@ public class IntellijMockBase {
 		when(module.getName()).thenReturn("module");
 		when(module.getProject()).thenReturn(project);
 		when(module.getService(InfinitestLauncher.class)).thenReturn(launcher);
+		when(module.getService(ModuleSettings.class)).thenReturn(moduleSettings);
+		
+		when(moduleSettings.getRuntimeEnvironment()).thenReturn(runtimeEnvironment);
 		
 		when(moduleManager.getModules()).thenReturn(new Module[] {module});
 		


### PR DESCRIPTION
When opening a project with no JDK (e.g. a javascript project) we try to build the results tree and this fails when we try to get the RuntimeEnvironment of the module.