### PR TITLE
feature: run the tests when the filter file changes

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/FilterFileChangeProcessor.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/event/FilterFileChangeProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.eclipse.event;
+
+import static org.eclipse.core.resources.IResourceChangeEvent.POST_CHANGE;
+import static org.infinitest.config.FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.infinitest.eclipse.workspace.WorkspaceFacade;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Triggers a tests run when a filter file is updated, created, deleted
+ * 
+ * @author gtoison
+ */
+@Component
+class FilterFileChangeProcessor extends EclipseEventProcessor {
+	private final WorkspaceFacade workspace;
+
+	@Autowired
+	FilterFileChangeProcessor(WorkspaceFacade workspace) {
+		super("Filter file change processor");
+		this.workspace = workspace;
+	}
+
+	@Override
+	public boolean canProcessEvent(IResourceChangeEvent event) {
+		return (event.getType() & POST_CHANGE) > 0;
+	}
+
+	@Override
+	public void processEvent(IResourceChangeEvent event) throws CoreException {
+		FilterFileChangeProcessorVisitor visitor = new FilterFileChangeProcessorVisitor();
+		
+		findModifiedResources(visitor, getDeltas(event));
+		
+		if (!visitor.filterFileModified.isEmpty()) {
+			workspace.filterFileModified(visitor.filterFileModified);
+		}
+	}
+
+	private void findModifiedResources(FilterFileChangeProcessorVisitor visitor, IResourceDelta... deltas) throws CoreException {
+		for (IResourceDelta delta : deltas) {
+			delta.accept(visitor);
+		}
+	}
+	
+	public static class FilterFileChangeProcessorVisitor implements IResourceDeltaVisitor {
+		private Set<IResource> filterFileModified = new HashSet<>();
+		
+		@Override
+		public boolean visit(IResourceDelta d) throws CoreException {
+			if (isFilterFile(d)) {
+				filterFileModified.add(d.getResource());
+			}
+			
+			return true;
+		}
+		private boolean isFilterFile(IResourceDelta delta) {
+			return delta.getFullPath().toPortableString().endsWith(INFINITEST_FILTERS_FILE_NAME);
+		}
+	}
+}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseConfigurationSource.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseConfigurationSource.java
@@ -25,28 +25,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.parser;
+package org.infinitest.eclipse.workspace;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.Set;
 
-import org.infinitest.environment.ClasspathProvider;
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
+import org.infinitest.config.InfinitestConfiguration;
+import org.infinitest.config.InfinitestConfigurationSource;
 
-public interface TestDetector {
-	void clear();
+/**
+ * @author gtoison
+ *
+ */
+public class EclipseConfigurationSource implements InfinitestConfigurationSource {
+	private ProjectFacade project;
 	
-	/**
-	 * @param removedFiles The removed files
-	 * @return the removed test classes
-	 */
-	Set<JavaClass> removeClasses(Collection<File> removedFiles);
+	public EclipseConfigurationSource(ProjectFacade project) {
+		this.project = project;
+	}
 
-	Set<JavaClass> findTestsToRun(Collection<File> changedFiles);
+	@Override
+	public InfinitestConfiguration getConfiguration() {
+		File file = getFile();
+		if (file.exists()) {
+			return FileBasedInfinitestConfigurationSource.createFromFile(getFile()).getConfiguration();
+		} else {
+			return InfinitestConfiguration.empty();
+		}
+	}
 
-	void setClasspathProvider(ClasspathProvider classpath);
-
-	Set<String> getCurrentTests();
-
-	void updateFilterList();
+	@Override
+	public File getFile() {
+		File workingDirectory = project.workingDirectory();
+		
+		return new File(workingDirectory, FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME);
+	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/ProjectFacade.java
@@ -27,20 +27,24 @@
  */
 package org.infinitest.eclipse.workspace;
 
-import static java.util.logging.Level.*;
-import static org.eclipse.core.resources.IMarker.*;
-import static org.eclipse.core.resources.IResource.*;
-import static org.eclipse.jdt.core.IJavaModelMarker.*;
-import static org.eclipse.jdt.launching.JavaRuntime.*;
-import static org.infinitest.util.InfinitestUtils.*;
+import static java.util.logging.Level.WARNING;
+import static org.eclipse.core.resources.IMarker.SEVERITY_ERROR;
+import static org.eclipse.core.resources.IResource.DEPTH_INFINITE;
+import static org.eclipse.jdt.core.IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER;
+import static org.eclipse.jdt.launching.JavaRuntime.getVMInstall;
+import static org.infinitest.util.InfinitestUtils.log;
 
-import java.io.*;
-import java.net.*;
+import java.io.File;
+import java.net.URI;
 
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.*;
-import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.launching.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
 
 class ProjectFacade implements EclipseProject {
 	private final IJavaProject project;
@@ -175,5 +179,9 @@ class ProjectFacade implements EclipseProject {
 	public boolean isOnClasspath(IResource resource) {
 		// isOnClasspath() does not seem to return true for a class in its own project
 		return project.isOnClasspath(resource) || resource.getProject().equals(project.getProject());
+	}
+	
+	public boolean contains(IResource resource) {
+		return resource.getProject().equals(project.getProject());
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceFacade.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/WorkspaceFacade.java
@@ -36,4 +36,6 @@ public interface WorkspaceFacade {
 	void updateProjects(Set<IResource> modifiedResources) throws CoreException;
 	
 	void remove(Set<IResource> removedResources);
+
+	void filterFileModified(Set<IResource> filterFiles);
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/FilterFileChangeProcessorTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/event/FilterFileChangeProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.eclipse.event;
+
+import static org.infinitest.config.FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.infinitest.eclipse.workspace.WorkspaceFacade;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author gtoison
+ *
+ */
+class FilterFileChangeProcessorTest {
+
+	@Test
+	void filterFileUpdate() throws CoreException {
+		WorkspaceFacade workspace = mock(WorkspaceFacade.class);
+		IResourceChangeEvent event = mock(IResourceChangeEvent.class);
+		IResourceDelta delta = mock(IResourceDelta.class);
+		IResourceDelta[] deltas = new IResourceDelta[] {mock(IResourceDelta.class)};
+		IResourceDelta filterDelta = mock(IResourceDelta.class);
+		IPath path = mock(IPath.class);
+		
+		when(event.getType()).thenReturn(IResourceChangeEvent.POST_CHANGE);
+		when(event.getDelta()).thenReturn(delta);
+		
+		when(delta.getAffectedChildren()).thenReturn(deltas);
+		
+		doAnswer(i -> {
+			i.getArgument(0, IResourceDeltaVisitor.class).visit(filterDelta);
+			return null;
+		}).when(deltas[0]).accept(any());
+		
+		when(filterDelta.getFullPath()).thenReturn(path);
+		when(path.toPortableString()).thenReturn(INFINITEST_FILTERS_FILE_NAME);
+		
+		FilterFileChangeProcessor processor = new FilterFileChangeProcessor(workspace);
+		
+		if (processor.canProcessEvent(event)) {
+			processor.processEvent(event);
+		}
+		
+		verify(workspace, times(1)).filterFileModified(anySet());
+	}
+}

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/ModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/ModuleSettings.java
@@ -27,9 +27,12 @@
  */
 package org.infinitest.intellij;
 
+import java.io.File;
+
 import org.infinitest.environment.RuntimeEnvironment;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
 
 public interface ModuleSettings {
 	void writeToLogger(Logger log);
@@ -37,4 +40,10 @@ public interface ModuleSettings {
 	String getName();
 
 	RuntimeEnvironment getRuntimeEnvironment();
+	
+	/**
+	 * @return The filter {@link File} for this {@link Module}, this should be either the filter file at
+	 * the root of the module folder or, if there isn't a file there the project root, or <code>null</code>
+	 */
+	File getFilterFile();
 }

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/FilterFileWatcher.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/FilterFileWatcher.java
@@ -1,0 +1,91 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.intellij.idea;
+
+import static org.infinitest.config.FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME;
+
+import java.util.List;
+
+import org.infinitest.InfinitestCore;
+import org.infinitest.TestControl;
+import org.infinitest.intellij.plugin.launcher.InfinitestLauncher;
+import org.jetbrains.annotations.NotNull;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+
+/**
+ * Watches for changes (saved, deleted, created, etc.) on files named 'infinitest.filters'. When a change is detected
+ * in a project this triggers a run of all the enabled tests. We're running all the tests because the filters mix
+ * different kinds of logic to exclude/include tests (regex on the name, JUnit annotations) so the plugin cannot
+ * easily compute a diff of the new/old tests
+ * 
+ * @author gtoison
+ */
+public class FilterFileWatcher implements BulkFileListener {
+	private Project project;
+
+	public FilterFileWatcher(Project project) {
+		this.project = project;
+	}
+	
+	@Override
+	public void after(@NotNull List<? extends @NotNull VFileEvent> events) {
+		ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
+		
+		for (VFileEvent event : events) {
+			if (event.getPath().endsWith(INFINITEST_FILTERS_FILE_NAME)) {
+				VirtualFile file = event.getFile();
+				// The javadoc says that the file might be null
+				if (file != null && projectFileIndex.isInContent(file)) {
+					runEnabledTests();
+					return;
+				}
+			}
+		}
+	}
+
+	public void runEnabledTests() {
+		TestControl testControl = project.getService(ProjectTestControl.class);
+		if (testControl.shouldRunTests()) {
+			for (Module module : ModuleManager.getInstance(project).getModules()) {
+				if (testControl.shouldRunTests(module)) {
+					InfinitestLauncher launcher = module.getService(InfinitestLauncher.class);
+					InfinitestCore core = launcher.getCore();
+					
+					core.filterFileWasUpdated();
+				}
+			}
+		}
+	}
+}

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaInfinitestConfigurationSource.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaInfinitestConfigurationSource.java
@@ -25,28 +25,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.parser;
+package org.infinitest.intellij.idea;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.Set;
 
-import org.infinitest.environment.ClasspathProvider;
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
+import org.infinitest.config.InfinitestConfiguration;
+import org.infinitest.config.InfinitestConfigurationSource;
+import org.infinitest.intellij.ModuleSettings;
 
-public interface TestDetector {
-	void clear();
+import com.intellij.openapi.module.Module;
+
+/**
+ * @author gtoison
+ *
+ */
+public class IdeaInfinitestConfigurationSource implements InfinitestConfigurationSource {
+	private Module module;
 	
-	/**
-	 * @param removedFiles The removed files
-	 * @return the removed test classes
-	 */
-	Set<JavaClass> removeClasses(Collection<File> removedFiles);
+	public IdeaInfinitestConfigurationSource(Module module) {
+		this.module = module;
+	}
 
-	Set<JavaClass> findTestsToRun(Collection<File> changedFiles);
+	@Override
+	public InfinitestConfiguration getConfiguration() {
+		File filterFile = getFile();
+		if (filterFile != null) {
+			return FileBasedInfinitestConfigurationSource.createFromFile(filterFile).getConfiguration();
+		} else {
+			return InfinitestConfiguration.empty();
+		}
+	}
 
-	void setClasspathProvider(ClasspathProvider classpath);
+	@Override
+	public File getFile() {
+		ModuleSettings moduleSettings = module.getService(ModuleSettings.class);
+		return moduleSettings.getFilterFile();
+	}
 
-	Set<String> getCurrentTests();
-
-	void updateFilterList();
 }

--- a/infinitest-intellij/src/main/resources/META-INF/plugin.xml
+++ b/infinitest-intellij/src/main/resources/META-INF/plugin.xml
@@ -31,14 +31,18 @@
     
     <projectListeners>
     	<listener class="org.infinitest.intellij.idea.IdeaCompilationListener" topic="com.intellij.task.ProjectTaskListener"/>
+        <listener class="org.infinitest.intellij.idea.FilterFileWatcher" topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
     </projectListeners>
     
 	<extensions defaultExtensionNs="com.intellij">
-    	<toolWindow id="Infinitest" icon="AllIcons.General.Modified" anchor="bottom" factoryClass="org.infinitest.intellij.idea.window.InfinitestToolWindowFactory"/>
-    	
-    	<projectService serviceInterface="org.infinitest.intellij.InfinitestAnnotator" serviceImplementation="org.infinitest.intellij.idea.language.IdeaInfinitestAnnotator"/>
-    	
-	    <moduleService serviceInterface="org.infinitest.intellij.ModuleSettings" serviceImplementation="org.infinitest.intellij.idea.IdeaModuleSettings"/>
-    	<moduleService serviceInterface="org.infinitest.intellij.plugin.launcher.InfinitestLauncher" serviceImplementation="org.infinitest.intellij.plugin.launcher.InfinitestLauncherImpl"/>
+        <toolWindow id="Infinitest" icon="AllIcons.General.Modified" anchor="bottom" factoryClass="org.infinitest.intellij.idea.window.InfinitestToolWindowFactory"/>
+
+        <projectService serviceInterface="org.infinitest.intellij.InfinitestAnnotator" serviceImplementation="org.infinitest.intellij.idea.language.IdeaInfinitestAnnotator"/>
+
+        <moduleService serviceInterface="org.infinitest.config.InfinitestConfigurationSource" serviceImplementation="org.infinitest.intellij.idea.IdeaInfinitestConfigurationSource"/>
+        <moduleService serviceInterface="org.infinitest.intellij.ModuleSettings" serviceImplementation="org.infinitest.intellij.idea.IdeaModuleSettings"/>
+        <moduleService serviceInterface="org.infinitest.intellij.plugin.launcher.InfinitestLauncher" serviceImplementation="org.infinitest.intellij.plugin.launcher.InfinitestLauncherImpl"/>
+
+        <applicationConfigurable parentId="tools" instance="org.infinitest.intellij.ApplicationSettingConfigurable" id="org.infinitest.intellij.ApplicationSettingConfigurable" displayName="Infinitest Settings"/>
 	</extensions>
 </idea-plugin>

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/FakeModuleSettings.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/FakeModuleSettings.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.environment.RuntimeEnvironment;
 
 import com.intellij.openapi.diagnostic.Logger;
@@ -70,6 +71,16 @@ public class FakeModuleSettings implements ModuleSettings {
 	@Override
 	public RuntimeEnvironment getRuntimeEnvironment() {
 		String systemClasspath = System.getProperty("java.class.path");
-		return new RuntimeEnvironment(new File(getProperty("java.home")), new File("."), systemClasspath, systemClasspath , Collections.<File> emptyList(), "");
+		return new RuntimeEnvironment(new File(getProperty("java.home")),
+				new File("."),
+				systemClasspath, systemClasspath,
+				Collections.<File>emptyList(),
+				null,
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
+	}
+	
+	@Override
+	public File getFilterFile() {
+		return null;
 	}
 }

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -53,6 +53,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.util.messages.MessageBus;
@@ -70,6 +71,7 @@ public class IntellijMockBase {
 	
 	protected MessageBus messageBus;
 	protected MessageBusConnection messageBusConnection;
+	protected ProjectFileIndex projectFileIndex;
 	
 	protected InfinitestLauncher launcher;
 	protected ProjectTestControl control;
@@ -82,6 +84,7 @@ public class IntellijMockBase {
 		moduleManager = mock(ModuleManager.class);
 		messageBus = mock(MessageBus.class);
 		messageBusConnection = mock(MessageBusConnection.class);
+		projectFileIndex = mock(ProjectFileIndex.class);
 		launcher = mock(InfinitestLauncher.class);
 		control = new ProjectTestControl(project);
 		annotator = mock(InfinitestAnnotator.class);
@@ -90,6 +93,7 @@ public class IntellijMockBase {
 		when(project.getMessageBus()).thenReturn(messageBus);
 		when(project.getService(ProjectTestControl.class)).thenReturn(control);
 		when(project.getService(InfinitestAnnotator.class)).thenReturn(annotator);
+		when(project.getService(ProjectFileIndex.class)).thenReturn(projectFileIndex);
 		
 		when(module.getName()).thenReturn("module");
 		when(module.getProject()).thenReturn(project);

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/FilterFileWatcherTest.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/FilterFileWatcherTest.java
@@ -1,0 +1,125 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.intellij.idea;
+
+import static org.infinitest.config.FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.infinitest.InfinitestCore;
+import org.infinitest.intellij.IntellijMockBase;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.verification.VerificationModeFactory;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+
+/**
+ * @author gtoison
+ *
+ */
+class FilterFileWatcherTest extends IntellijMockBase {
+	@Test
+	void shouldIgnoreNonFilterFile() {
+		FilterFileWatcher watcher = new FilterFileWatcher(project);
+		VFileEvent event = mock(VFileEvent.class);
+		
+		when(event.getPath()).thenReturn("foo");
+		
+		watcher.after(Collections.singletonList(event));
+		
+		verifyNoInteractions(launcher);
+	}
+
+	@Test
+	void shouldIgnoreNullFile() {
+		FilterFileWatcher watcher = new FilterFileWatcher(project);
+		VFileEvent event = mock(VFileEvent.class);
+		
+		when(event.getPath()).thenReturn(INFINITEST_FILTERS_FILE_NAME);
+		
+		watcher.after(Collections.singletonList(event));
+		
+		verifyNoInteractions(launcher);
+	}
+
+	@Test
+	void shouldIgnoreFileNotInProject() {
+		FilterFileWatcher watcher = new FilterFileWatcher(project);
+		VFileEvent event = mock(VFileEvent.class);
+		VirtualFile file = mock(VirtualFile.class);
+		
+		when(event.getPath()).thenReturn(INFINITEST_FILTERS_FILE_NAME);
+		when(event.getFile()).thenReturn(file);
+		when(projectFileIndex.isInContent(file)).thenReturn(false);
+		
+		watcher.after(Collections.singletonList(event));
+		
+		verifyNoInteractions(launcher);
+	}
+
+	@Test
+	void shouldNotRunTestsWhenDisabled() {
+		setupApplication(true);
+		
+		FilterFileWatcher watcher = new FilterFileWatcher(project);
+		VFileEvent event = mock(VFileEvent.class);
+		VirtualFile file = mock(VirtualFile.class);
+		
+		when(event.getPath()).thenReturn(INFINITEST_FILTERS_FILE_NAME);
+		when(event.getFile()).thenReturn(file);
+		when(projectFileIndex.isInContent(file)).thenReturn(true);
+		
+		watcher.after(Collections.singletonList(event));
+		
+		verifyNoInteractions(launcher);
+	}
+
+	@Test
+	void shouldRunTestsWhenEnabled() {
+		setupApplication(false);
+		
+		FilterFileWatcher watcher = new FilterFileWatcher(project);
+		VFileEvent event = mock(VFileEvent.class);
+		VirtualFile file = mock(VirtualFile.class);
+		InfinitestCore core = mock(InfinitestCore.class);
+		
+		when(event.getPath()).thenReturn(INFINITEST_FILTERS_FILE_NAME);
+		when(event.getFile()).thenReturn(file);
+		when(projectFileIndex.isInContent(file)).thenReturn(true);
+		when(launcher.getCore()).thenReturn(core);
+		
+		watcher.after(Collections.singletonList(event));
+		
+		verify(core, VerificationModeFactory.times(1)).filterFileWasUpdated();
+	}
+}

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaInfinitestConfigurationSourceTest.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaInfinitestConfigurationSourceTest.java
@@ -25,33 +25,49 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.intellij.plugin.launcher;
+package org.infinitest.intellij.idea;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinitest.config.FileBasedInfinitestConfigurationSource.INFINITEST_FILTERS_FILE_NAME;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.infinitest.config.FileBasedInfinitestConfigurationSource;
-import org.infinitest.config.InfinitestConfigurationSource;
-import org.infinitest.environment.RuntimeEnvironment;
+import java.io.File;
+
 import org.infinitest.intellij.IntellijMockBase;
 import org.infinitest.intellij.ModuleSettings;
 import org.junit.jupiter.api.Test;
 
-class InfinitestLauncherImplTest extends IntellijMockBase {
+/**
+ * @author gtoison
+ *
+ */
+class IdeaInfinitestConfigurationSourceTest extends IntellijMockBase {
+
 	@Test
-	void launcherInitiatilization() {
+	void noFilterFile() {
 		ModuleSettings moduleSettings = mock(ModuleSettings.class);
-		RuntimeEnvironment runtimeEnvironment = mock(RuntimeEnvironment.class);
-		InfinitestConfigurationSource configurationSource = FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory();
-		
 		when(module.getService(ModuleSettings.class)).thenReturn(moduleSettings);
-		when(moduleSettings.getRuntimeEnvironment()).thenReturn(runtimeEnvironment);
-		when(runtimeEnvironment.getConfigurationSource()).thenReturn(configurationSource);
 		
-		InfinitestLauncherImpl launcher = new InfinitestLauncherImpl(module);
+		IdeaInfinitestConfigurationSource configurationSource = new IdeaInfinitestConfigurationSource(module);
 		
-		assertThat(launcher.getCore()).isNotNull();
-		assertThat(launcher.getResultCollector()).isNotNull();
+		assertNotNull(configurationSource.getConfiguration());
+		
+		verify(moduleSettings, times(1)).getFilterFile();
+	}
+	
+	@Test
+	void filterFile() {
+		ModuleSettings moduleSettings = mock(ModuleSettings.class);
+		when(module.getService(ModuleSettings.class)).thenReturn(moduleSettings);
+		when(moduleSettings.getFilterFile()).thenReturn(new File(INFINITEST_FILTERS_FILE_NAME));
+		
+		IdeaInfinitestConfigurationSource configurationSource = new IdeaInfinitestConfigurationSource(module);
+		
+		assertNotNull(configurationSource.getConfiguration());
+		
+		verify(moduleSettings, times(1)).getFilterFile();
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/DefaultInfinitestCore.java
@@ -27,18 +27,27 @@
  */
 package org.infinitest;
 
-import static com.google.common.collect.Sets.*;
-import static java.util.logging.Level.*;
-import static org.infinitest.util.InfinitestUtils.*;
+import static com.google.common.collect.Sets.difference;
+import static java.util.logging.Level.CONFIG;
+import static org.infinitest.util.InfinitestUtils.log;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
-import org.infinitest.changedetect.*;
+import org.infinitest.changedetect.ChangeDetector;
 import org.infinitest.environment.RuntimeEnvironment;
-import org.infinitest.parser.*;
-import org.infinitest.testrunner.*;
-import org.infinitest.testrunner.queue.*;
+import org.infinitest.parser.JavaClass;
+import org.infinitest.parser.TestDetector;
+import org.infinitest.testrunner.RunStatistics;
+import org.infinitest.testrunner.TestCaseEvent;
+import org.infinitest.testrunner.TestResultsListener;
+import org.infinitest.testrunner.TestRunner;
+import org.infinitest.testrunner.queue.TestComparator;
 
 /**
  * @author <a href="mailto:benrady@gmail.com">Ben Rady</a>
@@ -119,6 +128,7 @@ class DefaultInfinitestCore implements InfinitestCore {
 	@Override
 	public void reload() {
 		log("Reloading core " + name);
+		testDetector.updateFilterList();
 		testDetector.clear();
 		changeDetector.clear();
 		firstRunSinceReload = true;
@@ -227,6 +237,12 @@ class DefaultInfinitestCore implements InfinitestCore {
 	@Override
 	public boolean isEventSourceFor(TestCaseEvent testCaseEvent) {
 		return testCaseEvent.getSource().equals(getRunner());
+	}
+	
+	@Override
+	public void filterFileWasUpdated() {
+		reload();
+		update();
 	}
 
 	TestRunner getRunner() {

--- a/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
+++ b/infinitest-lib/src/main/java/org/infinitest/InfinitestCore.java
@@ -112,4 +112,9 @@ public interface InfinitestCore {
 
 	void removeConsoleOutputListener(ConsoleOutputListener listener);
 
+	/**
+	 * To be called when the filter file was modified, created or deleted
+	 */
+	void filterFileWasUpdated();
+
 }

--- a/infinitest-lib/src/main/java/org/infinitest/InfinitestCoreBuilder.java
+++ b/infinitest-lib/src/main/java/org/infinitest/InfinitestCoreBuilder.java
@@ -30,8 +30,6 @@ package org.infinitest;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.infinitest.changedetect.FileChangeDetector;
-import org.infinitest.config.FileBasedInfinitestConfigurationSource;
-import org.infinitest.config.InfinitestConfigurationSource;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.filter.RegexFileFilter;
 import org.infinitest.filter.TestFilter;
@@ -60,8 +58,7 @@ public class InfinitestCoreBuilder {
 		this.eventQueue = eventQueue;
 		this.coreName = coreName;
 		
-		InfinitestConfigurationSource configSource = FileBasedInfinitestConfigurationSource.createFromWorkingDirectory(environment.getWorkingDirectory());
-		filterList = new RegexFileFilter(configSource);
+		filterList = new RegexFileFilter(environment.getConfigurationSource());
 		runnerClass = MultiProcessRunner.class;
 		controller = new SingleLockConcurrencyController();
 	}

--- a/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
+++ b/infinitest-lib/src/main/java/org/infinitest/environment/RuntimeEnvironment.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.logging.Level;
 
 import org.infinitest.classloader.ClassPathFileClassLoader;
+import org.infinitest.config.InfinitestConfigurationSource;
 import org.infinitest.testrunner.TestRunnerProcess;
 import org.infinitest.util.InfinitestUtils;
 
@@ -98,7 +99,8 @@ public class RuntimeEnvironment implements ClasspathProvider {
 	private List<File> classDirs;
 	private final CustomJvmArgumentsReader customArgumentsReader;
 	private final String runnerBootstrapClassPath;
-
+	private final InfinitestConfigurationSource configurationSource;
+	
 	/**
 	 * Creates a new environment for test execution.
 	 * 
@@ -121,15 +123,24 @@ public class RuntimeEnvironment implements ClasspathProvider {
 	 *            The classpath used to launch the tests. It must include the test
 	 *            classes and their dependencies (including directories in
 	 *            classOutputDirs). it must not include infinitest itself.
+	 * @param configurationSource
+	 *            The configuration source, the file used by this source might change to another file
 	 */
-	public RuntimeEnvironment(File javaHome, File workingDirectory, String runnerBootstrapClassPath,
-			String runnerProcessClassPath, List<File> classOutputDirs, String projectUnderTestClassPath) {
+	public RuntimeEnvironment(File javaHome,
+			File workingDirectory,
+			String runnerBootstrapClassPath,
+			String runnerProcessClassPath,
+			List<File> classOutputDirs,
+			String projectUnderTestClassPath,
+			InfinitestConfigurationSource configurationSource) {
 		this.classOutputDirs = classOutputDirs;
 		this.workingDirectory = workingDirectory;
 		this.javaHome = javaHome;
 		this.runnerBootstrapClassPath = runnerBootstrapClassPath;
 		this.runnerProcessClassPath = runnerProcessClassPath;
 		this.projectUnderTestClassPath = projectUnderTestClassPath;
+		this.configurationSource = configurationSource;
+		
 		additionalArgs = new ArrayList<>();
 		customArgumentsReader = new FileCustomJvmArgumentReader(workingDirectory);
 	}
@@ -231,6 +242,13 @@ public class RuntimeEnvironment implements ClasspathProvider {
 	 */
 	public File getWorkingDirectory() {
 		return workingDirectory;
+	}
+	
+	/**
+	 * @return The configuration source
+	 */
+	public InfinitestConfigurationSource getConfigurationSource() {
+		return configurationSource;
 	}
 
 	public void addVMArgs(List<String> newArgs) {

--- a/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
+++ b/infinitest-lib/src/main/java/org/infinitest/parser/ClassFileTestDetector.java
@@ -68,7 +68,7 @@ public class ClassFileTestDetector implements TestDetector {
 	 */
 	@Override
 	public synchronized Set<JavaClass> findTestsToRun(Collection<File> changedFiles) {
-		filters.updateFilterList();
+		updateFilterList();
 
 		// Find changed classes
 		Set<JavaClass> changedClasses = index.findClasses(changedFiles);
@@ -80,6 +80,11 @@ public class ClassFileTestDetector implements TestDetector {
 		// run through total set, and pick out tests to run
 		log(Level.FINE, "Total changeset: " + changedParents);
 		return filterTests(changedClasses);
+	}
+
+	@Override
+	public void updateFilterList() {
+		filters.updateFilterList();
 	}
 
 	private Set<JavaClass> filterTests(Set<JavaClass> changedClasses) {

--- a/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeConnectionFactory.java
+++ b/infinitest-lib/src/main/java/org/infinitest/testrunner/process/NativeConnectionFactory.java
@@ -31,6 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.logging.Level.CONFIG;
 import static org.infinitest.util.InfinitestUtils.log;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -88,7 +89,7 @@ public class NativeConnectionFactory implements ProcessConnectionFactory {
 		builder.directory(environment.getWorkingDirectory());
 
 		List<String> arguments = environment.createProcessArguments(classpathArgumentBuilder);
-		arguments.addAll(buildRunnerArgs(port));
+		arguments.addAll(buildRunnerArgs(port, environment));
 		builder.command(arguments);
 
 		builder.environment().putAll(environment.createProcessEnvironment());
@@ -113,10 +114,18 @@ public class NativeConnectionFactory implements ProcessConnectionFactory {
 		return message.toString();
 	}
 
-	private Collection<String> buildRunnerArgs(int portNum) {
+	private Collection<String> buildRunnerArgs(int portNum, RuntimeEnvironment environment) {
+		File filterFile = environment.getConfigurationSource().getFile();
+		
+		String filterFilePath = "null";
+		if (filterFile != null) {
+			filterFilePath = filterFile.getAbsolutePath();
+		}
+		
 		return asList(
 				TestRunnerProcess.class.getName(), 
 				runnerClass.getName(), 
-				String.valueOf(portNum));
+				String.valueOf(portNum),
+				filterFilePath);
 	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
+++ b/infinitest-lib/src/test/java/org/infinitest/FakeInfinitestCore.java
@@ -27,71 +27,93 @@
  */
 package org.infinitest;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collection;
+import java.util.Set;
 
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.parser.JavaClass;
-import org.infinitest.testrunner.*;
+import org.infinitest.testrunner.TestCaseEvent;
+import org.infinitest.testrunner.TestResultsListener;
 
 @SuppressWarnings("all")
 public class FakeInfinitestCore implements InfinitestCore {
+	@Override
 	public void addTestQueueListener(TestQueueListener listener) {
 	}
 
+	@Override
 	public void removeTestQueueListener(TestQueueListener listener) {
 	}
 
+	@Override
 	public void addTestResultsListener(TestResultsListener listener) {
 	}
 
+	@Override
 	public void removeTestResultsListener(TestResultsListener listener) {
 	}
 
+	@Override
 	public int update() {
 		return 0;
 	}
 
+	@Override
 	public void reload() {
 	}
 
+	@Override
 	public void setRuntimeEnvironment(RuntimeEnvironment environment) {
 	}
 
+	@Override
 	public String getName() {
 		return null;
 	}
 
+	@Override
 	public void addConsoleOutputListener(ConsoleOutputListener listener) {
 	}
 
+	@Override
 	public void removeConsoleOutputListener(ConsoleOutputListener listener) {
 	}
 
 	public void addReloadListener(ReloadListener listener) {
 	}
 
+	@Override
 	public void addDisabledTestListener(DisabledTestListener listener) {
 	}
 
+	@Override
 	public void removeDisabledTestListener(DisabledTestListener anyObject) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public RuntimeEnvironment getRuntimeEnvironment() {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public boolean isEventSourceFor(TestCaseEvent testCaseEvent) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public int update(Collection<File> changedFiles) {
 		throw new UnsupportedOperationException();
 	}
 	
 	@Override
 	public void remove(Collection<File> removedFiles, Set<JavaClass> removedClasses) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public void filterFileWasUpdated() {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/StubTestDetector.java
+++ b/infinitest-lib/src/test/java/org/infinitest/StubTestDetector.java
@@ -76,4 +76,9 @@ class StubTestDetector implements TestDetector {
 	public Set<String> getCurrentTests() {
 		return emptySet();
 	}
+	
+	@Override
+	public void updateFilterList() {
+		// Doing nothing here
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/WhenSearchingForClassFilesToIndex.java
+++ b/infinitest-lib/src/test/java/org/infinitest/WhenSearchingForClassFilesToIndex.java
@@ -34,18 +34,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.List;
 
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.junit.jupiter.api.Test;
 
 class WhenSearchingForClassFilesToIndex {
-  @Test
-  void shouldSearchClassDirectoriesOnTheClasspath() {
-    File outputDir = new File("target/classes");
-    List<File> outputDirs = asList(outputDir);
-    String classpath = "target/classes" + pathSeparator + "target/test-classes";
-    RuntimeEnvironment environment = new RuntimeEnvironment(new File("javahome"), new File("."), "runnerClassLoaderClassPath", "runnerProcessClassPath", outputDirs, classpath);
-    List<File> directoriesInClasspath = environment.classDirectoriesInClasspath();
+	@Test
+	void shouldSearchClassDirectoriesOnTheClasspath() {
+		File outputDir = new File("target/classes");
+		List<File> outputDirs = asList(outputDir);
+		String classpath = "target/classes" + pathSeparator + "target/test-classes";
+		RuntimeEnvironment environment = new RuntimeEnvironment(
+				new File("javahome"),
+				new File("."),
+				"runnerClassLoaderClassPath",
+				"runnerProcessClassPath",
+				outputDirs,
+				classpath,
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
+		List<File> directoriesInClasspath = environment.classDirectoriesInClasspath();
 
-    assertThat(directoriesInClasspath).contains(new File("target/test-classes"), outputDir);
-  }
+		assertThat(directoriesInClasspath).contains(new File("target/test-classes"), outputDir);
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/environment/FakeEnvironments.java
+++ b/infinitest-lib/src/test/java/org/infinitest/environment/FakeEnvironments.java
@@ -27,14 +27,13 @@
  */
 package org.infinitest.environment;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.List;
 
-import org.infinitest.*;
-import org.infinitest.environment.ClasspathProvider;
-import org.infinitest.environment.RuntimeEnvironment;
+import org.infinitest.StandaloneClasspath;
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 
 public class FakeEnvironments {
 	public static File fakeClassDirectory() {
@@ -50,7 +49,13 @@ public class FakeEnvironments {
 	}
 
 	public static RuntimeEnvironment fakeEnvironment() {
-		return new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(), systemClasspath(), systemClasspath(), fakeBuildPaths(), systemClasspath());
+		return new RuntimeEnvironment(currentJavaHome(),
+				fakeWorkingDirectory(),
+				systemClasspath(),
+				systemClasspath(),
+				fakeBuildPaths(),
+				systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 	}
 
 	public static File fakeWorkingDirectory() {
@@ -66,11 +71,23 @@ public class FakeEnvironments {
 	}
 
 	public static RuntimeEnvironment emptyRuntimeEnvironment() {
-		return new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(), "infinitest-classloader.classpath", "infinitest-runner.classpath", asList(new File("thisdirectorydoesnotexist")), "classpath");
+		return new RuntimeEnvironment(currentJavaHome(),
+				fakeWorkingDirectory(),
+				"infinitest-classloader.classpath",
+				"infinitest-runner.classpath",
+				asList(new File("thisdirectorydoesnotexist")),
+				"classpath",
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 	}
 
 	public static RuntimeEnvironment fakeVeryLongClasspathEnvironment() {
-		return new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(), fakeVeryLongClassPaths(), fakeVeryLongClassPaths(), fakeBuildPaths(), fakeVeryLongClassPaths());
+		return new RuntimeEnvironment(currentJavaHome(),
+				fakeWorkingDirectory(),
+				fakeVeryLongClassPaths(),
+				fakeVeryLongClassPaths(),
+				fakeBuildPaths(),
+				fakeVeryLongClassPaths(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 	}
 
 	private static String fakeVeryLongClassPaths() {

--- a/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/environment/RuntimeEnvironmentTest.java
@@ -42,7 +42,6 @@ import static org.infinitest.environment.FakeEnvironments.systemClasspath;
 import static org.infinitest.util.InfinitestUtils.addLoggingListener;
 import static org.infinitest.util.InfinitestUtils.convertFromWindowsClassPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -56,6 +55,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.environment.RuntimeEnvironment.JavaHomeException;
 import org.infinitest.util.LoggingAdapter;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,9 +119,13 @@ class RuntimeEnvironmentTest {
 
 	@Test
 	void shouldThrowExceptionOnInvalidJavaHome() {
-		RuntimeEnvironment environment = new RuntimeEnvironment(javaHome, fakeWorkingDirectory(),
-				"runnerClassLoaderClassPath", "runnerProcessClassPath", fakeBuildPaths(),
-				FakeEnvironments.systemClasspath());
+		RuntimeEnvironment environment = new RuntimeEnvironment(javaHome,
+				fakeWorkingDirectory(),
+				"runnerClassLoaderClassPath",
+				"runnerProcessClassPath",
+				fakeBuildPaths(),
+				FakeEnvironments.systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 		try {
 			ClasspathArgumentBuilder classpathArgumentBuilder = mock(ClasspathArgumentBuilder.class);
 			environment.createProcessArguments(classpathArgumentBuilder);
@@ -134,9 +138,13 @@ class RuntimeEnvironmentTest {
 
 	@Test
 	void shouldAllowAlternateJavaHomesOnUnixAndWindows() throws Exception {
-		RuntimeEnvironment environment = new RuntimeEnvironment(javaHome, fakeWorkingDirectory(),
-				"runnerClassLoaderClassPath", "runnerProcessClassPath", fakeBuildPaths(),
-				FakeEnvironments.systemClasspath());
+		RuntimeEnvironment environment = new RuntimeEnvironment(javaHome,
+				fakeWorkingDirectory(),
+				"runnerClassLoaderClassPath",
+				"runnerProcessClassPath",
+				fakeBuildPaths(),
+				FakeEnvironments.systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 
 		touch(new File(javaHome, "bin/java.exe"));
 		ClasspathArgumentBuilder classpathArgumentBuilder = mock(ClasspathArgumentBuilder.class);
@@ -152,8 +160,14 @@ class RuntimeEnvironmentTest {
 
 	@Test
 	void shouldAddInfinitestJarOrClassDirToClasspath() {
-		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(),
-				systemClasspath(), systemClasspath(), fakeBuildPaths(), systemClasspath());
+		RuntimeEnvironment environment = new RuntimeEnvironment(
+				currentJavaHome(),
+				fakeWorkingDirectory(),
+				systemClasspath(),
+				systemClasspath(),
+				fakeBuildPaths(),
+				systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 		String classpath = environment.getRunnerFullClassPath();
 		assertTrue(classpath.contains("infinitest"));
 		assertTrue(classpath.endsWith(environment.findInfinitestRunnerJar()), classpath);
@@ -164,8 +178,14 @@ class RuntimeEnvironmentTest {
 		LoggingAdapter listener = new LoggingAdapter();
 		addLoggingListener(listener);
 
-		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(),
-				systemClasspath(), systemClasspath(), fakeBuildPaths(), systemClasspath());
+		RuntimeEnvironment environment = new RuntimeEnvironment(
+				currentJavaHome(),
+				fakeWorkingDirectory(),
+				systemClasspath(),
+				systemClasspath(),
+				fakeBuildPaths(),
+				systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 		Map<String, String> env = environment.createProcessEnvironment();
 		assertThat(env).containsEntry("CLASSPATH", environment.getRunnerBootstrapClassPath());
 	}
@@ -190,9 +210,13 @@ class RuntimeEnvironmentTest {
 
 	@Test
 	void shouldLogWarningIfClasspathContainsMissingFilesOrDirectories() {
-		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(), 
+		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(),
 				fakeWorkingDirectory(),
-				systemClasspath(), systemClasspath(), fakeBuildPaths(), "classpath");
+				systemClasspath(),
+				systemClasspath(),
+				fakeBuildPaths(),
+				"classpath",
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 		LoggingAdapter adapter = new LoggingAdapter();
 		addLoggingListener(adapter);
 		environment.getRunnerFullClassPath();
@@ -220,9 +244,13 @@ class RuntimeEnvironmentTest {
 	}
 
 	private RuntimeEnvironment createEnv(String outputDir, String workingDir, String classpath, String javahome) {
-		RuntimeEnvironment env = new RuntimeEnvironment(new File(javahome), new File(workingDir),
-				"runnerClassLoaderClassPath", "runnerProcessClassPath", asList(new File(outputDir)), classpath);
-		return env;
+		return new RuntimeEnvironment(new File(javahome),
+				new File(workingDir),
+				"runnerClassLoaderClassPath",
+				"runnerProcessClassPath",
+				asList(new File(outputDir)),
+				classpath,
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 	}
 
 	private RuntimeEnvironment createEqualInstance() {
@@ -237,7 +265,8 @@ class RuntimeEnvironmentTest {
 				"runnerClassLoaderClassPath",
 				"runnerProcessClassPath",
 				Collections.singletonList(new File("outputDir")),
-				classpath) {
+				classpath,
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory()) {
 			@Override
 			String findInfinitestRunnerJar() {
 				return "c:/test path/runner.jar";

--- a/infinitest-lib/src/test/java/org/infinitest/plugin/WhenConfiguringBuilder.java
+++ b/infinitest-lib/src/test/java/org/infinitest/plugin/WhenConfiguringBuilder.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import org.infinitest.FakeEventQueue;
 import org.infinitest.InfinitestCore;
 import org.infinitest.InfinitestCoreBuilder;
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.filter.TestFilter;
 import org.infinitest.parser.TestDetector;
@@ -51,7 +52,14 @@ class WhenConfiguringBuilder {
 
 	@BeforeEach
 	final void mustProvideRuntimeEnvironmentAndEventQueue() {
-		RuntimeEnvironment environment = new RuntimeEnvironment(currentJavaHome(), fakeWorkingDirectory(), systemClasspath(), systemClasspath(), fakeBuildPaths(), systemClasspath());
+		RuntimeEnvironment environment = new RuntimeEnvironment(
+				currentJavaHome(),
+				fakeWorkingDirectory(),
+				systemClasspath(),
+				systemClasspath(),
+				fakeBuildPaths(),
+				systemClasspath(),
+				FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory());
 		builder = new InfinitestCoreBuilder(environment, new FakeEventQueue(), "myCoreName");
 	}
 

--- a/infinitest-lib/src/test/java/org/infinitest/testrunner/WhenRunningTestsInDifferentEnvironments.java
+++ b/infinitest-lib/src/test/java/org/infinitest/testrunner/WhenRunningTestsInDifferentEnvironments.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.File;
 
 import org.infinitest.EventSupport;
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.environment.FakeEnvironments;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.util.InfinitestTestUtils;
@@ -70,7 +71,13 @@ class WhenRunningTestsInDifferentEnvironments extends AbstractRunnerTest {
 
   @Test
   void canUseACustomWorkingDirectory() throws Exception {
-    runner.setRuntimeEnvironment(new RuntimeEnvironment(currentJavaHome(), new File("src"), FakeEnvironments.systemClasspath(), FakeEnvironments.systemClasspath(), fakeBuildPaths(), FakeEnvironments.systemClasspath()));
+    runner.setRuntimeEnvironment(new RuntimeEnvironment(currentJavaHome(),
+        new File("src"),
+        FakeEnvironments.systemClasspath(),
+        FakeEnvironments.systemClasspath(),
+        fakeBuildPaths(),
+        FakeEnvironments.systemClasspath(),
+        FileBasedInfinitestConfigurationSource.createFromCurrentWorkingDirectory()));
     runTests(WorkingDirectoryVerifier.class);
     eventAssert.assertTestPassed(WorkingDirectoryVerifier.class);
   }

--- a/infinitest-runner/src/main/java/org/infinitest/config/FileBasedInfinitestConfigurationSource.java
+++ b/infinitest-runner/src/main/java/org/infinitest/config/FileBasedInfinitestConfigurationSource.java
@@ -29,14 +29,14 @@ package org.infinitest.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharSource;
 import com.google.common.io.Files;
 
 public class FileBasedInfinitestConfigurationSource implements InfinitestConfigurationSource {
 
-	private static final String INFINITEST_FILTERS_FILE_NAME = "infinitest.filters";
+	public static final String INFINITEST_FILTERS_FILE_NAME = "infinitest.filters";
 	private final File file;
 
 	private FileBasedInfinitestConfigurationSource(File file) {
@@ -45,10 +45,10 @@ public class FileBasedInfinitestConfigurationSource implements InfinitestConfigu
 
 	@Override
 	public InfinitestConfiguration getConfiguration() {
-		if (!file.exists()) {
+		if (file == null || !file.exists()) {
 			return InfinitestConfiguration.empty();
 		}
-		CharSource charSource = Files.asCharSource(file, Charsets.UTF_8);
+		CharSource charSource = Files.asCharSource(file, StandardCharsets.UTF_8);
 		try {
 			return new InfinitestConfigurationParser().parseFileContent(charSource);
 		} catch (IOException e) {
@@ -70,4 +70,8 @@ public class FileBasedInfinitestConfigurationSource implements InfinitestConfigu
 		return createFromWorkingDirectory(workingDirectory);
 	}
 
+	@Override
+	public File getFile() {
+		return file;
+	}
 }

--- a/infinitest-runner/src/main/java/org/infinitest/config/InfinitestConfigurationSource.java
+++ b/infinitest-runner/src/main/java/org/infinitest/config/InfinitestConfigurationSource.java
@@ -27,7 +27,15 @@
  */
 package org.infinitest.config;
 
+import java.io.File;
+
 public interface InfinitestConfigurationSource {
 
 	InfinitestConfiguration getConfiguration();
+	
+	/**
+	 * We need to tell the test runner process where to get its configuration file
+	 * @return The file used for this configuration or <code>null</code> if there isn't one
+	 */
+	File getFile();
 }

--- a/infinitest-runner/src/main/java/org/infinitest/config/MemoryInfinitestConfigurationSource.java
+++ b/infinitest-runner/src/main/java/org/infinitest/config/MemoryInfinitestConfigurationSource.java
@@ -27,6 +27,8 @@
  */
 package org.infinitest.config;
 
+import java.io.File;
+
 public class MemoryInfinitestConfigurationSource implements InfinitestConfigurationSource {
 
 	private InfinitestConfiguration configuration;
@@ -44,4 +46,8 @@ public class MemoryInfinitestConfigurationSource implements InfinitestConfigurat
 		return configuration;
 	}
 
+	@Override
+	public File getFile() {
+		return null;
+	}
 }

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/DefaultRunner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/DefaultRunner.java
@@ -43,6 +43,7 @@ public class DefaultRunner implements NativeRunner {
 			.createFromCurrentWorkingDirectory();
 
 	// to override the default config source for unit tests
+	@Override
 	public void setTestConfigurationSource(InfinitestConfigurationSource configurationSource) {
 		configSource = configurationSource;
 	}

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/NativeRunner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/NativeRunner.java
@@ -27,6 +27,8 @@
  */
 package org.infinitest.testrunner;
 
+import org.infinitest.config.InfinitestConfigurationSource;
+
 /**
  * Implementers of this interface must provide a default constructor so that
  * the TestRunner can be created using Class.newInstance();
@@ -35,4 +37,7 @@ package org.infinitest.testrunner;
  */
 public interface NativeRunner {
 	TestResults runTest(String testClass);
+	
+	default void setTestConfigurationSource(InfinitestConfigurationSource configurationSource) {
+	}
 }

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
@@ -30,11 +30,14 @@ package org.infinitest.testrunner;
 import static org.infinitest.testrunner.TestEvent.methodFailed;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+
+import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 
 // RISK This class is only tested by running it, which is slow and throws off coverage
 public class TestRunnerProcess {
@@ -42,8 +45,8 @@ public class TestRunnerProcess {
 	
 	private NativeRunner runner;
 
-	private TestRunnerProcess(String runnerClass) {
-		createRunner(runnerClass);
+	private TestRunnerProcess(String runnerClass, File filterFile) {
+		createRunner(runnerClass, filterFile);
 	}
 
 	private static void checkForJUnit4() {
@@ -54,8 +57,12 @@ public class TestRunnerProcess {
 		}
 	}
 
-	private void createRunner(String runnerClassName) {
+	private void createRunner(String runnerClassName, File filterFile) {
 		runner = instantiateTestRunner(runnerClassName);
+		
+		if (filterFile != null && filterFile.exists()) {
+			runner.setTestConfigurationSource(FileBasedInfinitestConfigurationSource.createFromFile(filterFile));
+		}
 	}
 
 	private NativeRunner instantiateTestRunner(String runnerClassName) {
@@ -74,11 +81,12 @@ public class TestRunnerProcess {
 	public static void main(String[] args) {
 		try {
 			checkForJUnit4();			
-			if (args.length != 2) {
-				throw new IllegalArgumentException("runner expects two parameters: runnerClass and port");
+			if (args.length != 3) {
+				throw new IllegalArgumentException("runner expects three parameters: runnerClass, port and filterFile");
 			}
 			String runnerClass = args[0];
-			TestRunnerProcess process = new TestRunnerProcess(runnerClass);
+			File filterFile = getFilterFile(args);
+			TestRunnerProcess process = new TestRunnerProcess(runnerClass, filterFile);
 			int portNum = Integer.parseInt(args[1]);
 			Socket clientSocket = new Socket("127.0.0.1", portNum);
 			// DEBT Extract this to a reader class
@@ -108,6 +116,14 @@ public class TestRunnerProcess {
 			System.exit(0);
 		}
 
+	}
+
+	private static File getFilterFile(String[] args) {
+		if (!"null".equals(args[2])) {
+			return new File(args[2]);
+		} else {
+			return null;
+		}
 	}
 
 	private static void writeTestResultToOutputStream(TestRunnerProcess process, ObjectOutputStream outputStream, String testName) throws IOException {


### PR DESCRIPTION
- Added a configuration source object to the runtime environment so we can let the plugins return the correct file when they call the runner.
- For the IntelliJ plugin the filter file may be at the root of the project or the module, so we need to handle the case when it was in the project and a new filter file is added in the module
- Watch for changes on the filter file and run tests