### PR TITLE
feature: configurable severity for Eclipse markers

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
@@ -54,7 +54,7 @@ public class SlowTestObserver implements DisabledTestListener, TestResultsListen
 		// The whole process of detecting passing/failing/ignored/disabled tests
 		// is remarkably
 		// similar to the process of detecting slow/fast/ignored/disabled tests.
-		SlowTestMarkerInfo marker = new SlowTestMarkerInfo(testName, newStats, lookup);
+		SlowTestMarkerInfo marker = new SlowTestMarkerInfo(testName, newStats, lookup, slowMarkerRegistry.markerServerity());
 		if (newStats.duration() > getSlowTestTimeLimit()) {
 			slowMarkerRegistry.addMarker(marker);
 		} else {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
@@ -172,7 +172,7 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 		IProgressMonitor monitor = new NullProgressMonitor();
 		
 		for (IMarker marker : markers.values()) {
-			UpdateMarkersOperation operation = new UpdateMarkersOperation(markersArray, attributes, "Infinitest markers update", true);
+			UpdateMarkersOperation operation = buildUpdateMarkersAction(attributes, markersArray);
 			
 			try {
 				operation.execute(monitor, marker.getResource());
@@ -180,6 +180,10 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 				log("Error updating marker severity " + marker, e);
 			}
 		}
+	}
+
+	protected UpdateMarkersOperation buildUpdateMarkersAction(Map<String, Integer> attributes, IMarker[] markers) {
+		return new UpdateMarkersOperation(markers, attributes, "Infinitest markers update", true);
 	}
 	
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
@@ -27,12 +27,23 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static org.infinitest.util.InfinitestUtils.*;
+import static org.infinitest.util.InfinitestUtils.log;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import org.eclipse.core.resources.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.ui.ide.undo.UpdateMarkersOperation;
+import org.infinitest.eclipse.InfinitestPlugin;
 
 /**
  * This would be a nice feature someday: <a
@@ -43,10 +54,33 @@ import org.eclipse.core.runtime.*;
 public class GenericMarkerRegistry implements MarkerRegistry {
 	private final Map<MarkerInfo, IMarker> markers;
 	private final String markerId;
+	private int markerSeverity;
 
-	public GenericMarkerRegistry(String markerId) {
+	public GenericMarkerRegistry(String markerId, String severityPerferrenceKey) {
+		this(markerId, getPreferredSeverity(severityPerferrenceKey));
+	}
+
+	public GenericMarkerRegistry(String markerId, int markerSeverity) {
 		this.markerId = markerId;
+		this.markerSeverity = markerSeverity;
 		markers = new HashMap<>();
+	}
+
+	private static int getPreferredSeverity(String severityPerferrenceKey) {
+		InfinitestPlugin plugin = InfinitestPlugin.getInstance();
+		// The plugin is null in unit tests
+		if (plugin != null) {
+			String value = plugin.getPreferenceStore().getString(severityPerferrenceKey);
+			if (value != null && !value.isEmpty()) {
+				try {
+					return Integer.parseInt(value);
+				} catch (NumberFormatException e) {
+					log("Error getting preferred marker severity for " + severityPerferrenceKey, e);
+				}
+			}
+		}
+		
+		return IMarker.SEVERITY_ERROR;
 	}
 
 	@Override
@@ -126,5 +160,30 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 
 	public int markerCount() {
 		return getMarkers().size();
+	}
+	
+	@Override
+	public void updateMarkersSeverity(int markersSeverity) {
+		this.markerSeverity = markersSeverity;
+		
+		Map<String, Integer> attributes = Collections.singletonMap(IMarker.SEVERITY, markerSeverity);
+		IMarker[] markersArray = markers.values().toArray(new IMarker[0]);
+		
+		IProgressMonitor monitor = new NullProgressMonitor();
+		
+		for (IMarker marker : markers.values()) {
+			UpdateMarkersOperation operation = new UpdateMarkersOperation(markersArray, attributes, "Infinitest markers update", true);
+			
+			try {
+				operation.execute(monitor, marker.getResource());
+			} catch (ExecutionException e) {
+				log("Error updating marker severity " + marker, e);
+			}
+		}
+	}
+	
+	@Override
+	public int markerServerity() {
+		return markerSeverity;
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/MarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/MarkerRegistry.java
@@ -27,6 +27,8 @@
  */
 package org.infinitest.eclipse.markers;
 
+import org.eclipse.core.resources.IMarker;
+
 public interface MarkerRegistry {
 	void addMarker(MarkerInfo marker);
 
@@ -37,4 +39,12 @@ public interface MarkerRegistry {
 	void updateMarker(MarkerInfo marker);
 
 	void removeMarkers(String testName);
+
+	/**
+	 * Updates the severity of all the markers
+	 * @param markersSeverity The new marker severity, for instance {@link IMarker#SEVERITY_ERROR}
+	 */
+	void updateMarkersSeverity(int markersSeverity);
+	
+	int markerServerity();
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerRegistry.java
@@ -27,13 +27,18 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static org.infinitest.eclipse.PluginConstants.*;
+import static org.infinitest.eclipse.PluginConstants.PROBLEM_MARKER_ID;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILED_TEST_MARKER_SEVERITY;
 
-import org.springframework.stereotype.*;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ProblemMarkerRegistry extends GenericMarkerRegistry {
 	public ProblemMarkerRegistry() {
-		super(PROBLEM_MARKER_ID);
+		super(PROBLEM_MARKER_ID, FAILED_TEST_MARKER_SEVERITY);
+	}
+	
+	public ProblemMarkerRegistry(int markerSeverity) {
+		super(PROBLEM_MARKER_ID, markerSeverity);
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerRegistry.java
@@ -37,8 +37,4 @@ public class ProblemMarkerRegistry extends GenericMarkerRegistry {
 	public ProblemMarkerRegistry() {
 		super(PROBLEM_MARKER_ID, FAILED_TEST_MARKER_SEVERITY);
 	}
-	
-	public ProblemMarkerRegistry(int markerSeverity) {
-		super(PROBLEM_MARKER_ID, markerSeverity);
-	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowMarkerRegistry.java
@@ -27,13 +27,18 @@
  */
 package org.infinitest.eclipse.markers;
 
-import static org.infinitest.eclipse.PluginConstants.*;
+import static org.infinitest.eclipse.PluginConstants.SLOW_MARKER_ID;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_MARKER_SEVERITY;
 
-import org.springframework.stereotype.*;
+import org.springframework.stereotype.Component;
 
 @Component
 public class SlowMarkerRegistry extends GenericMarkerRegistry {
 	public SlowMarkerRegistry() {
-		super(SLOW_MARKER_ID);
+		super(SLOW_MARKER_ID, SLOW_TEST_MARKER_SEVERITY);
+	}
+	
+	public SlowMarkerRegistry(int markerSeverity) {
+		super(SLOW_MARKER_ID, markerSeverity);
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowTestMarkerInfo.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/SlowTestMarkerInfo.java
@@ -42,11 +42,13 @@ public class SlowTestMarkerInfo extends AbstractMarkerInfo {
 	private final String testName;
 	private final MethodStats methodStats;
 	private final ResourceLookup lookup;
-
-	public SlowTestMarkerInfo(String testName, MethodStats methodStats, ResourceLookup lookup) {
+	private final int markerSeverity;
+	
+	public SlowTestMarkerInfo(String testName, MethodStats methodStats, ResourceLookup lookup, int markerSeverity) {
 		this.testName = testName;
 		this.methodStats = methodStats;
 		this.lookup = lookup;
+		this.markerSeverity = markerSeverity;
 	}
 
 	@Override
@@ -61,7 +63,7 @@ public class SlowTestMarkerInfo extends AbstractMarkerInfo {
 	@Override
 	public Map<String, Object> attributes() {
 		Map<String, Object> markerAttributes = newLinkedHashMap();
-		markerAttributes.put(SEVERITY, SEVERITY_WARNING);
+		markerAttributes.put(SEVERITY, markerSeverity);
 		markerAttributes.put(MESSAGE, buildMessage());
 
 		return markerAttributes;

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -55,7 +55,6 @@ public class PreferenceChangeHandler {
 	private final CoreSettings coreSettings;
 	private ProblemMarkerRegistry problemMarkerRegistry;
 	private SlowMarkerRegistry slowMarkerRegistry;
-	private boolean clearProblemMarkerRegistry;
 	private boolean clearSlowMarkerRegistry;
 
 	@Autowired
@@ -134,7 +133,6 @@ public class PreferenceChangeHandler {
 
 	public void setProblemMarkerRegistry(ProblemMarkerRegistry bean) {
 		problemMarkerRegistry = bean;
-		clearProblemMarkerRegistry = false;
 	}
 
 	public void setSlowMarkerRegistry(SlowMarkerRegistry bean) {
@@ -143,25 +141,13 @@ public class PreferenceChangeHandler {
 	}
 
 	public void applyChanges() {
-		if (clearProblemMarkerRegistry) {
-			clearProblemMarkers();
-		}
-		
 		if (clearSlowMarkerRegistry) {
 			clearSlowMarkers();
 		}
 	}
 
 	public void clearChanges() {
-		clearProblemMarkerRegistry = false;
 		clearSlowMarkerRegistry = false;
-	}
-
-	public void clearProblemMarkers() {
-		clearProblemMarkerRegistry = false;
-		if (problemMarkerRegistry != null) {
-			problemMarkerRegistry.clear();
-		}
 	}
 
 	public void clearSlowMarkers() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -27,26 +27,35 @@
  */
 package org.infinitest.eclipse.prefs;
 
-import static java.lang.Integer.*;
-import static org.apache.commons.lang.StringUtils.*;
-import static org.eclipse.jface.preference.FieldEditor.*;
-import static org.infinitest.eclipse.prefs.PreferencesConstants.*;
-import static org.infinitest.util.InfinitestGlobalSettings.*;
+import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.eclipse.jface.preference.FieldEditor.VALUE;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.AUTO_TEST;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILED_TEST_MARKER_SEVERITY;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_MARKER_SEVERITY;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
+import static org.infinitest.util.InfinitestGlobalSettings.setSlowTestTimeLimit;
 
-import org.eclipse.jface.preference.*;
-import org.eclipse.jface.util.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.markers.*;
-import org.infinitest.eclipse.trim.*;
-import org.infinitest.eclipse.workspace.*;
-import org.springframework.beans.factory.annotation.*;
-import org.springframework.stereotype.*;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.infinitest.eclipse.PluginActivationController;
+import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
+import org.infinitest.eclipse.markers.SlowMarkerRegistry;
+import org.infinitest.eclipse.trim.ColorSettings;
+import org.infinitest.eclipse.workspace.CoreSettings;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class PreferenceChangeHandler {
 	private final PluginActivationController controller;
 	private final CoreSettings coreSettings;
+	private ProblemMarkerRegistry problemMarkerRegistry;
 	private SlowMarkerRegistry slowMarkerRegistry;
+	private boolean clearProblemMarkerRegistry;
 	private boolean clearSlowMarkerRegistry;
 
 	@Autowired
@@ -65,9 +74,13 @@ public class PreferenceChangeHandler {
 			updateSlowTestWarning((String) newValue);
 		} else if (PARALLEL_CORES.equals(preference)) {
 			updateConcurrency((String) newValue);
-		} else if (PreferencesConstants.FAILING_BACKGROUND_COLOR.equals(preference)) {
+		} else if (FAILED_TEST_MARKER_SEVERITY.equals(preference)) {
+			updateFailedTestMarkerSeverity((String) newValue);
+		} else if (SLOW_TEST_MARKER_SEVERITY.equals(preference)) {
+			updateSlowTestMarkerSeverity((String) newValue);
+		} else if (FAILING_BACKGROUND_COLOR.equals(preference)) {
 			updateFailingBackgroundColor((String) newValue);
-		} else if (PreferencesConstants.FAILING_TEXT_COLOR.equals(preference)) {
+		} else if (FAILING_TEXT_COLOR.equals(preference)) {
 			updateFailingTextColor((String) newValue);
 		}
 	}
@@ -103,6 +116,14 @@ public class PreferenceChangeHandler {
 		}
 	}
 
+	private void updateFailedTestMarkerSeverity(String newValue) {
+		problemMarkerRegistry.updateMarkersSeverity(Integer.parseInt(newValue));
+	}
+
+	private void updateSlowTestMarkerSeverity(String newValue) {
+		slowMarkerRegistry.updateMarkersSeverity(Integer.parseInt(newValue));
+	}
+
 	private String findChangedPreference(PropertyChangeEvent event) {
 		Object source = event.getSource();
 		if ((source instanceof FieldEditor) && event.getProperty().equals(VALUE)) {
@@ -111,20 +132,36 @@ public class PreferenceChangeHandler {
 		return null;
 	}
 
+	public void setProblemMarkerRegistry(ProblemMarkerRegistry bean) {
+		problemMarkerRegistry = bean;
+		clearProblemMarkerRegistry = false;
+	}
+
 	public void setSlowMarkerRegistry(SlowMarkerRegistry bean) {
 		slowMarkerRegistry = bean;
 		clearSlowMarkerRegistry = false;
 	}
 
 	public void applyChanges() {
+		if (clearProblemMarkerRegistry) {
+			clearProblemMarkers();
+		}
+		
 		if (clearSlowMarkerRegistry) {
 			clearSlowMarkers();
 		}
-
 	}
 
 	public void clearChanges() {
+		clearProblemMarkerRegistry = false;
 		clearSlowMarkerRegistry = false;
+	}
+
+	public void clearProblemMarkers() {
+		clearProblemMarkerRegistry = false;
+		if (problemMarkerRegistry != null) {
+			problemMarkerRegistry.clear();
+		}
 	}
 
 	public void clearSlowMarkers() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -143,9 +143,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	public void performDefaults() {
-		handler.clearProblemMarkers();
 		handler.clearSlowMarkers();
-		
 		super.performDefaults();
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -32,7 +32,9 @@ import static org.infinitest.eclipse.prefs.PreferencesConstants.AUTO_TEST;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
 
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -42,6 +44,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.infinitest.MultiCoreConcurrencyController;
 import org.infinitest.eclipse.InfinitestPlugin;
+import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
 import org.infinitest.eclipse.markers.SlowMarkerRegistry;
 
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
@@ -53,6 +56,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	PreferencePage(PreferenceChangeHandler changeHandler) {
 		handler = changeHandler;
+		handler.setProblemMarkerRegistry(InfinitestPlugin.getInstance().getBean(ProblemMarkerRegistry.class));
 		handler.setSlowMarkerRegistry(InfinitestPlugin.getInstance().getBean(SlowMarkerRegistry.class));
 	}
 
@@ -71,6 +75,8 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		addField(createAutoTestEditor());
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
+		addField(createSeverityEditor(PreferencesConstants.FAILED_TEST_MARKER_SEVERITY, "Failed test severity"));
+		addField(createSeverityEditor(PreferencesConstants.SLOW_TEST_MARKER_SEVERITY, "Slow test severity"));
 		addField(createFailingBackgroundColorEditor());
 		addField(createFailingTextColorEditor());
 	}
@@ -101,6 +107,15 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		return editor;
 	}
 
+	private ComboFieldEditor createSeverityEditor(String name, String labelText) {
+		String[][] values = new String[][] {
+		    {"Info", String.valueOf(IMarker.SEVERITY_INFO)},
+		    {"Warning", String.valueOf(IMarker.SEVERITY_WARNING)},
+		    {"Error", String.valueOf(IMarker.SEVERITY_ERROR)}};
+		    
+		return new ComboFieldEditor(name, labelText, values, getFieldEditorParent());
+	}
+
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {
 		handler.propertyChange(event);
@@ -126,7 +141,9 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	@Override
 	public void performDefaults() {
+		handler.clearProblemMarkers();
 		handler.clearSlowMarkers();
+		
 		super.performDefaults();
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -51,13 +51,15 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	private final PreferenceChangeHandler handler;
 
 	public PreferencePage() {
-		this(InfinitestPlugin.getInstance().getBean(PreferenceChangeHandler.class));
+		this(InfinitestPlugin.getInstance().getBean(PreferenceChangeHandler.class),
+				InfinitestPlugin.getInstance().getBean(ProblemMarkerRegistry.class),
+				InfinitestPlugin.getInstance().getBean(SlowMarkerRegistry.class));
 	}
 
-	PreferencePage(PreferenceChangeHandler changeHandler) {
+	PreferencePage(PreferenceChangeHandler changeHandler, ProblemMarkerRegistry problemMarkerRegistry, SlowMarkerRegistry slowMarkerRegistry) {
 		handler = changeHandler;
-		handler.setProblemMarkerRegistry(InfinitestPlugin.getInstance().getBean(ProblemMarkerRegistry.class));
-		handler.setSlowMarkerRegistry(InfinitestPlugin.getInstance().getBean(SlowMarkerRegistry.class));
+		handler.setProblemMarkerRegistry(problemMarkerRegistry);
+		handler.setSlowMarkerRegistry(slowMarkerRegistry);
 	}
 
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -40,6 +40,10 @@ public abstract class PreferencesConstants {
 	public static final String PARALLEL_CORES = "org.infinitest.eclipse.parallel";
 
 	public static final String SLOW_TEST_WARNING = "org.infinitest.eclipse.slow-warning";
+	
+	public static final String FAILED_TEST_MARKER_SEVERITY = "org.infinitest.eclipse.failed.test.marker.severity";
+	
+	public static final String SLOW_TEST_MARKER_SEVERITY = "org.infinitest.eclipse.slow.test.marker.severity";
 
 	public static final String FAILING_BACKGROUND_COLOR = "org.infinitest.eclipse.color.failing.background";
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenMarkingTestsAsSlow.java
@@ -54,7 +54,7 @@ class WhenMarkingTestsAsSlow extends EqualityTestSupport {
 		resourceLookup = mock(ResourceLookup.class);
 		MethodStats stats = new MethodStats("shouldRunSlowly");
 		stats.stop(5000);
-		marker = new SlowTestMarkerInfo(TEST_NAME, stats, resourceLookup);
+		marker = new SlowTestMarkerInfo(TEST_NAME, stats, resourceLookup, IMarker.SEVERITY_WARNING);
 	}
 
 	@Test
@@ -84,11 +84,11 @@ class WhenMarkingTestsAsSlow extends EqualityTestSupport {
 
 	@Override
 	protected Object createEqualInstance() {
-		return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunSlowly"), resourceLookup);
+		return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunSlowly"), resourceLookup, IMarker.SEVERITY_ERROR);
 	}
 
 	@Override
 	protected Object createUnequalInstance() {
-		return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunQuickly"), resourceLookup);
+		return new SlowTestMarkerInfo(TEST_NAME, new MethodStats("shouldRunQuickly"), resourceLookup, IMarker.SEVERITY_ERROR);
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
+import org.eclipse.core.resources.IMarker;
 import org.infinitest.eclipse.markers.*;
 import org.infinitest.eclipse.workspace.*;
 import org.infinitest.testrunner.*;
@@ -52,7 +53,7 @@ class WhenWatchingForSlowTests {
 		mockMarkerRegistry = mock(SlowMarkerRegistry.class);
 		methodStats = new MethodStats("shouldRunSlowly");
 		ResourceLookup resourceLookup = mock(ResourceLookup.class);
-		expectedMarker = new SlowTestMarkerInfo("MyTest", methodStats, resourceLookup);
+		expectedMarker = new SlowTestMarkerInfo("MyTest", methodStats, resourceLookup, IMarker.SEVERITY_ERROR);
 		setSlowTestTimeLimit(2000);
 		observer = new SlowTestObserver(mockMarkerRegistry, resourceLookup);
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
@@ -183,6 +183,8 @@ class WhenCreatingMarkers {
 		registry.updateMarkersSeverity(SEVERITY_INFO);
 		
 		verify(updateMarkersOperation).execute(any(), any());
+		
+		assertEquals(SEVERITY_INFO, registry.markerServerity());
 	}
 
 	private void addMarker(TestEvent event) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
@@ -51,7 +51,7 @@ class WhenCreatingMarkers {
 	@BeforeEach
 	void inContext() {
 		error = new AssertionError();
-		registry = new GenericMarkerRegistry(PROBLEM_MARKER_ID);
+		registry = new GenericMarkerRegistry(PROBLEM_MARKER_ID, IMarker.SEVERITY_ERROR);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
@@ -58,7 +58,6 @@ class PreferencePageTest {
 		preferencePage.createFieldEditors();
 		preferencePage.performDefaults();
 		
-		verify(changeHandler).clearProblemMarkers();
 		verify(changeHandler).clearSlowMarkers();
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
@@ -1,0 +1,66 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.eclipse.prefs;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
+import org.infinitest.eclipse.markers.SlowMarkerRegistry;
+import org.junit.jupiter.api.Test;
+
+class PreferencePageTest {
+
+	@Test
+	void test() throws Exception {
+		PreferenceChangeHandler changeHandler = mock(PreferenceChangeHandler.class);
+		ProblemMarkerRegistry problemMarkerRegistry = mock(ProblemMarkerRegistry.class);
+		SlowMarkerRegistry slowMarkerRegistry = mock(SlowMarkerRegistry.class);
+		
+		Display display = new Display();
+		Composite parent = new Shell(display);
+		
+		PreferencePage preferencePage = new PreferencePage(changeHandler, problemMarkerRegistry, slowMarkerRegistry) {
+			@Override
+			protected Composite getFieldEditorParent() {
+				return parent;
+			}
+		};
+		
+		preferencePage.createFieldEditors();
+		preferencePage.performDefaults();
+		
+		verify(changeHandler).clearProblemMarkers();
+		verify(changeHandler).clearSlowMarkers();
+		
+		display.dispose();
+	}
+}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/PreferencePageTest.java
@@ -45,7 +45,7 @@ class PreferencePageTest {
 		ProblemMarkerRegistry problemMarkerRegistry = mock(ProblemMarkerRegistry.class);
 		SlowMarkerRegistry slowMarkerRegistry = mock(SlowMarkerRegistry.class);
 		
-		Display display = new Display();
+		Display display = Display.getCurrent();
 		Composite parent = new Shell(display);
 		
 		PreferencePage preferencePage = new PreferencePage(changeHandler, problemMarkerRegistry, slowMarkerRegistry) {
@@ -60,7 +60,5 @@ class PreferencePageTest {
 		
 		verify(changeHandler).clearProblemMarkers();
 		verify(changeHandler).clearSlowMarkers();
-		
-		display.dispose();
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -51,15 +51,22 @@ class WhenPreferencesAreChanged {
 	private PluginActivationController controller;
 	private PreferenceChangeHandler handler;
 	private CoreSettings coreSettings;
+	
+	private SlowMarkerRegistry slowMarkerRegistry;
+	private ProblemMarkerRegistry problemMarkerRegistry;
 
 	@BeforeEach
 	void setUp() {
 		controller = mock(PluginActivationController.class);
 		coreSettings = mock(CoreSettings.class);
 		eventSource = mock(BooleanFieldEditor.class);
+		
+		slowMarkerRegistry = mock(SlowMarkerRegistry.class);
+		problemMarkerRegistry = mock(ProblemMarkerRegistry.class);
 
 		handler = new PreferenceChangeHandler(controller, coreSettings);
-		handler.setSlowMarkerRegistry(new SlowMarkerRegistry(SEVERITY_WARNING));
+		handler.setSlowMarkerRegistry(slowMarkerRegistry);
+		handler.setProblemMarkerRegistry(problemMarkerRegistry);
 	}
 
 	@AfterEach
@@ -115,6 +122,20 @@ class WhenPreferencesAreChanged {
 		changeProperty(SwtColorFieldEditor.VALUE, String.valueOf(white), String.valueOf(yellow));
 
 		assertEquals(yellow, ColorSettings.getFailingTextColor());
+	}
+
+	@Test
+	void shouldMarketsWhenFailedTestSeverityChanges() {
+		when(eventSource.getPreferenceName()).thenReturn(FAILED_TEST_MARKER_SEVERITY);
+		changeProperty(SwtColorFieldEditor.VALUE, "2", "1");
+		verify(problemMarkerRegistry).updateMarkersSeverity(SEVERITY_WARNING);
+	}
+
+	@Test
+	void shouldMarketsWhenSlowTestSeverityChanges() {
+		when(eventSource.getPreferenceName()).thenReturn(SLOW_TEST_MARKER_SEVERITY);
+		changeProperty(SwtColorFieldEditor.VALUE, "2", "1");
+		verify(slowMarkerRegistry).updateMarkersSeverity(SEVERITY_WARNING);
 	}
 
 	@Test

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -27,6 +27,7 @@
  */
 package org.infinitest.eclipse.prefs;
 
+import static org.eclipse.core.resources.IMarker.SEVERITY_WARNING;
 import static org.eclipse.jface.preference.FieldEditor.*;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.*;
 import static org.infinitest.util.InfinitestGlobalSettings.*;
@@ -58,7 +59,7 @@ class WhenPreferencesAreChanged {
 		eventSource = mock(BooleanFieldEditor.class);
 
 		handler = new PreferenceChangeHandler(controller, coreSettings);
-		handler.setSlowMarkerRegistry(new SlowMarkerRegistry());
+		handler.setSlowMarkerRegistry(new SlowMarkerRegistry(SEVERITY_WARNING));
 	}
 
 	@AfterEach

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -127,14 +127,14 @@ class WhenPreferencesAreChanged {
 	@Test
 	void shouldMarketsWhenFailedTestSeverityChanges() {
 		when(eventSource.getPreferenceName()).thenReturn(FAILED_TEST_MARKER_SEVERITY);
-		changeProperty(SwtColorFieldEditor.VALUE, "2", "1");
+		changeProperty(VALUE, "2", "1");
 		verify(problemMarkerRegistry).updateMarkersSeverity(SEVERITY_WARNING);
 	}
 
 	@Test
 	void shouldMarketsWhenSlowTestSeverityChanges() {
 		when(eventSource.getPreferenceName()).thenReturn(SLOW_TEST_MARKER_SEVERITY);
-		changeProperty(SwtColorFieldEditor.VALUE, "2", "1");
+		changeProperty(VALUE, "2", "1");
 		verify(slowMarkerRegistry).updateMarkersSeverity(SEVERITY_WARNING);
 	}
 


### PR DESCRIPTION
Added configuration settings for the failed test and slow test markers
Fixes #186 