### PR TITLE
Use `OrderEnumerator` to get the class path elements

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -35,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.infinitest.environment.RuntimeEnvironment;
@@ -53,14 +52,8 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.CompilerModuleExtension;
-import com.intellij.openapi.roots.JdkOrderEntry;
-import com.intellij.openapi.roots.LibraryOrderEntry;
-import com.intellij.openapi.roots.ModuleOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.roots.OrderEnumerator;
-import com.intellij.openapi.roots.OrderRootType;
-import com.intellij.openapi.roots.OrderRootsEnumerator;
 import com.intellij.openapi.vfs.VirtualFile;
 
 public class IdeaModuleSettings implements ModuleSettings {
@@ -227,50 +220,15 @@ public class IdeaModuleSettings implements ModuleSettings {
 	List<File> listClasspathElements() {
 		// Classpath order is significant
 		List<File> classpathElements = new ArrayList<>();
-
-		// all our dependencies (recursively where needed)
-		for (OrderEntry entry : moduleRootManagerInstance().getOrderEntries()) {
-			List<VirtualFile> files = new ArrayList<>();
-
-			if (entry instanceof ModuleOrderEntry) {
-				/*
-				 * other modules we depend on -> they could depend on modules
-				 * themselves, so we need to add them recursively.
-				 */
-				Module currentModule = ((ModuleOrderEntry) entry).getModule();
-				if (currentModule != null) {
-					OrderRootsEnumerator enumerator = OrderEnumerator.orderEntries(currentModule)
-					.withoutSdk()
-					.productionOnly()
-					.recursively()
-					.classes();
-					
-					files.addAll(Arrays.asList(enumerator.getRoots()));
-				}
-			} else if (entry instanceof LibraryOrderEntry) {
-				/*
-				 * libraries cannot be recursive and we only need the classes of
-				 * them.
-				 */
-				LibraryOrderEntry libraryOrderEntry = (LibraryOrderEntry) entry;
-				files.addAll(Arrays.asList(libraryOrderEntry.getRootFiles(OrderRootType.CLASSES)));
-			} else if (!(entry instanceof JdkOrderEntry)) {
-				/*
-				 * all other cases (whichever they are) we want to have their
-				 * classes outputs.
-				 */
-				files.addAll(Arrays.asList(entry.getFiles(OrderRootType.CLASSES)));
-			}
-			for (VirtualFile virtualFile : files) {
-				classpathElements.add(new File(virtualFile.getPath()));
-			}
-		}
-
-		CompilerModuleExtension compilerExtension = compilerModuleExtension();
-		if (compilerExtension != null) {
-			for (VirtualFile virtualFile : compilerExtension.getOutputRoots(true)) {
-				classpathElements.add(new File(virtualFile.getPath()));
-			}
+		
+		VirtualFile[] files = OrderEnumerator.orderEntries(module)
+				.withoutSdk()
+				.recursively()
+				.classes()
+				.getRoots();
+		
+		for (VirtualFile virtualFile : files) {
+			classpathElements.add(new File(virtualFile.getPath()));
 		}
 
 		return classpathElements;

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -51,7 +51,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.CompilerModuleExtension;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderEnumerator;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -232,14 +231,6 @@ public class IdeaModuleSettings implements ModuleSettings {
 		}
 
 		return classpathElements;
-	}
-
-	ModuleRootManager moduleRootManagerInstance() {
-		return ModuleRootManager.getInstance(module);
-	}
-
-	CompilerModuleExtension compilerModuleExtension() {
-		return CompilerModuleExtension.getInstance(module);
 	}
 
 	protected String infinitestJarPath(String jarName) {

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/IdeaModuleSettings.java
@@ -241,7 +241,7 @@ public class IdeaModuleSettings implements ModuleSettings {
 				if (currentModule != null) {
 					OrderRootsEnumerator enumerator = OrderEnumerator.orderEntries(currentModule)
 					.withoutSdk()
-					.compileOnly()
+					.productionOnly()
 					.recursively()
 					.classes();
 					

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaModuleSettingsTest.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/IdeaModuleSettingsTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.infinitest.intellij.IntellijMockBase;
@@ -79,6 +80,11 @@ class IdeaModuleSettingsTest extends IntellijMockBase {
 			@Override
 			protected File getWorkingDirectory() {
 				return new File(".");
+			}
+			
+			@Override
+			List<File> listClasspathElements() {
+				return Collections.emptyList();
 			}
 		};
 		

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
@@ -28,7 +28,6 @@
 package org.infinitest.intellij.idea;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -117,7 +116,7 @@ class WhenBuildingIdeaModuleClassPath {
 		when(moduleRootManagerMock.orderEntries()).thenReturn(orderEntriesEnumerator);
 		
 		when(orderEntriesEnumerator.withoutSdk()).thenReturn(orderEntriesEnumerator);
-		when(orderEntriesEnumerator.compileOnly()).thenReturn(orderEntriesEnumerator);
+		when(orderEntriesEnumerator.productionOnly()).thenReturn(orderEntriesEnumerator);
 		when(orderEntriesEnumerator.recursively()).thenReturn(orderEntriesEnumerator);
 		when(orderEntriesEnumerator.classes()).thenReturn(orderRootsEnumerator);
 		when(orderRootsEnumerator.getRoots()).thenReturn(new VirtualFile[0]);

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/idea/WhenBuildingIdeaModuleClassPath.java
@@ -33,102 +33,50 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.List;
 
+import org.infinitest.intellij.IntellijMockBase;
 import org.junit.jupiter.api.Test;
 
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.CompilerModuleExtension;
-import com.intellij.openapi.roots.JdkOrderEntry;
-import com.intellij.openapi.roots.ModuleOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.roots.OrderEnumerator;
-import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.OrderRootsEnumerator;
 import com.intellij.openapi.vfs.VirtualFile;
 
-class WhenBuildingIdeaModuleClassPath {
+class WhenBuildingIdeaModuleClassPath extends IntellijMockBase {
 	private static final String PATH_A = "a";
 	private static final String PATH_B = "b";
 	private static final String PATH_C = "c";
 	private static final String PATH_D = "d";
 
-	private final CompilerModuleExtension compilerModuleExtension = mock(CompilerModuleExtension.class);
-	private final ModuleRootManager moduleRootManagerMock = mock(ModuleRootManager.class);
-	private final Module module = mock(Module.class);
-	private final IdeaModuleSettings ideaModuleSettingsSpy = spy(new IdeaModuleSettings(module));
-
 	@Test
 	void shouldIncludeAllCompilationClassesToClasspathElementsList() {
-		OrderEntry orderEntry1 = orderEntry();
-		OrderEntry orderEntry2 = orderEntry();
-		doReturn(new OrderEntry[] { orderEntry1, orderEntry2 }).when(moduleRootManagerMock).getOrderEntries();
-		doReturn(new VirtualFile[] { fileWith(PATH_D) }).when(compilerModuleExtension).getOutputRoots(true);
-		doReturn(new VirtualFile[] { fileWith(PATH_A), fileWith(PATH_B) }).when(orderEntry1).getFiles(OrderRootType.CLASSES);
-		doReturn(new VirtualFile[] { fileWith(PATH_C) }).when(orderEntry2).getFiles(OrderRootType.CLASSES);
-		doReturn(moduleRootManagerMock).when(ideaModuleSettingsSpy).moduleRootManagerInstance();
-		doReturn(compilerModuleExtension).when(ideaModuleSettingsSpy).compilerModuleExtension();
-
+		IdeaModuleSettings ideaModuleSettingsSpy = spy(new IdeaModuleSettings(module));
+		
+		OrderEnumerator orderEnumerator = mock(OrderEnumerator.class);
+		OrderRootsEnumerator orderRootsEnumerator = mock(OrderRootsEnumerator.class);
+		VirtualFile[] roots = new VirtualFile[] {
+				fileWith(PATH_A),
+				fileWith(PATH_B),
+				fileWith(PATH_C),
+				fileWith(PATH_D),
+		};
+		
+		when(orderEnumerator.withoutSdk()).thenReturn(orderEnumerator);
+		when(orderEnumerator.recursively()).thenReturn(orderEnumerator);
+		when(orderEnumerator.classes()).thenReturn(orderRootsEnumerator);
+		when(orderRootsEnumerator.getRoots()).thenReturn(roots);
+		
+		when(moduleRootManager.orderEntries()).thenReturn(orderEnumerator);
+		
 		final List<File> classPathElementsList = ideaModuleSettingsSpy.listClasspathElements();
 
-		assertThat(classPathElementsList.get(0).getPath()).isEqualTo(PATH_A);
-		assertThat(classPathElementsList.get(1).getPath()).isEqualTo(PATH_B);
-		assertThat(classPathElementsList.get(2).getPath()).isEqualTo(PATH_C);
-		assertThat(classPathElementsList.get(3).getPath()).isEqualTo(PATH_D);
 		assertThat(classPathElementsList).hasSize(4);
-	}
-	
-	@Test
-	void shouldExcludeJdkModules() {
-		OrderEntry jdkOrderEntry = mock(JdkOrderEntry.class);
-		doReturn(new OrderEntry[] { jdkOrderEntry }).when(moduleRootManagerMock).getOrderEntries();
-		doReturn(new VirtualFile[] { fileWith(PATH_D) }).when(compilerModuleExtension).getOutputRoots(true);
-		doReturn(new VirtualFile[] { fileWith(PATH_C) }).when(jdkOrderEntry).getFiles(OrderRootType.CLASSES);
-		doReturn(moduleRootManagerMock).when(ideaModuleSettingsSpy).moduleRootManagerInstance();
-		doReturn(compilerModuleExtension).when(ideaModuleSettingsSpy).compilerModuleExtension();
-		
-		final List<File> classPathElementsList = ideaModuleSettingsSpy.listClasspathElements();
-		
-		verifyNoInteractions(jdkOrderEntry);
-		assertThat(classPathElementsList).hasSize(1);
-	}
-	
-	@Test
-	void shouldExcludeJdkModuleFromModuleDependencies() {
-		ModuleOrderEntry moduleOrderEntry = mock(ModuleOrderEntry.class);
-		doReturn(new OrderEntry[] { moduleOrderEntry }).when(moduleRootManagerMock).getOrderEntries();
-		doReturn(new VirtualFile[] { fileWith(PATH_D) }).when(compilerModuleExtension).getOutputRoots(true);
-		doReturn(new VirtualFile[] { fileWith(PATH_C) }).when(moduleOrderEntry).getFiles(OrderRootType.CLASSES);
-		doReturn(moduleRootManagerMock).when(ideaModuleSettingsSpy).moduleRootManagerInstance();
-		doReturn(compilerModuleExtension).when(ideaModuleSettingsSpy).compilerModuleExtension();
-		
-		Module dependentModule = mock(Module.class);
-		OrderEnumerator orderEntriesEnumerator = mock(OrderEnumerator.class);
-		OrderRootsEnumerator orderRootsEnumerator = mock(OrderRootsEnumerator.class); 
-		when(moduleOrderEntry.getModule()).thenReturn(dependentModule);
-		when(dependentModule.getComponent(ModuleRootManager.class)).thenReturn(moduleRootManagerMock);
-		when(moduleRootManagerMock.orderEntries()).thenReturn(orderEntriesEnumerator);
-		
-		when(orderEntriesEnumerator.withoutSdk()).thenReturn(orderEntriesEnumerator);
-		when(orderEntriesEnumerator.productionOnly()).thenReturn(orderEntriesEnumerator);
-		when(orderEntriesEnumerator.recursively()).thenReturn(orderEntriesEnumerator);
-		when(orderEntriesEnumerator.classes()).thenReturn(orderRootsEnumerator);
-		when(orderRootsEnumerator.getRoots()).thenReturn(new VirtualFile[0]);
-		
-		final List<File> classPathElementsList = ideaModuleSettingsSpy.listClasspathElements();
-	
-		assertThat(classPathElementsList).hasSize(1);
-		verify(orderEntriesEnumerator, times(1)).withoutSdk();
-	}
-
-	private static OrderEntry orderEntry() {
-		return mock(OrderEntry.class);
+		verify(orderEnumerator, times(1)).withoutSdk();
 	}
 
 	private static VirtualFile fileWith(final String path) {


### PR DESCRIPTION
For Gradle projects the resources folders are not included in the classpath, `CompilerModuleExtension` only gets the classes output folders but Gradle puts the resources in `build/resources/test`

For Maven projects the current code includes the test resources of dependent modules while the IntelliJ test runner only includes the test resources of the current module.

Simplifying the code seems to resolve both issues