### PR TITLE
feature: added an option to let tests run when projects have errors

### DIFF
--- a/infinitest-eclipse/plugin.xml
+++ b/infinitest-eclipse/plugin.xml
@@ -7,34 +7,37 @@
 	</extension>
 	<extension point="org.eclipse.ui.ide.markerResolution">
 		<markerResolutionGenerator class="org.infinitest.eclipse.resolution.MarkerResolutionGenerator">
-     </markerResolutionGenerator>
+		</markerResolutionGenerator>
 	</extension>
 	<extension point="org.eclipse.ui.preferencePages">
 		<page name="Infinitest" class="org.infinitest.eclipse.prefs.PreferencePage" id="org.infinitest.eclipse.prefs.view">
-     </page>
+		</page>
+	</extension>
+	<extension point="org.eclipse.core.runtime.preferences">
+		<initializer class="org.infinitest.eclipse.prefs.InfinitestPreferenceInitializer"/>
 	</extension>
 	<extension point="org.eclipse.ui.startup">
 		<startup class="org.infinitest.eclipse.ContinuousTestingStarter"/>
 	</extension>
 	<extension id="org.infinitest.eclipse.slowmarker" name="Infinitest Slow Test Warning" point="org.eclipse.core.resources.markers">
 		<persistent value="false">
-     </persistent>
+		</persistent>
 		<super type="org.eclipse.core.resources.problemmarker">
-     </super>
+		</super>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<group id="org.infinitest.eclipse.trimwidget" separatorsVisible="true">
 			<location>
 				<bar type="trim">
-           </bar>
+				</bar>
 				<order position="before" relativeTo="status">
-           </order>
+				</order>
 			</location>
 		</group>
 		<widget class="org.infinitest.eclipse.trim.StatusBar" id="org.infinitest.eclipse.trim.status">
 			<location>
 				<bar path="org.infinitest.eclipse.trimwidget" type="trim">
-           </bar>
+				</bar>
 			</location>
 		</widget>
 	</extension>

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -30,17 +30,13 @@ package org.infinitest.eclipse;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Arrays.asList;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
-import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
-import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
-import static org.infinitest.util.InfinitestGlobalSettings.getSlowTestTimeLimit;
 import static org.infinitest.util.InfinitestUtils.addLoggingListener;
 
 import java.util.logging.Level;
 
 import org.eclipse.core.runtime.Preferences;
-import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.infinitest.eclipse.prefs.PreferencesConstants;
 import org.infinitest.eclipse.trim.ColorSettings;
@@ -95,15 +91,6 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 
 	public void startContinuouslyTesting() {
 		getPluginController().enable();
-	}
-
-	@Override
-	protected void initializeDefaultPreferences(IPreferenceStore store) {
-		store.setDefault(PARALLEL_CORES, 1);
-		store.setDefault(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, true);
-		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
-		store.setDefault(FAILING_BACKGROUND_COLOR, ColorSettings.getFailingBackgroundColor());
-		store.setDefault(FAILING_TEXT_COLOR, ColorSettings.getFailingTextColor());
 	}
 
 	// Only used for testing.

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -29,6 +29,7 @@ package org.infinitest.eclipse;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Arrays.asList;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
@@ -133,6 +134,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	@VisibleForTesting
 	void restoreSavedPreferences(Preferences preferences, CoreSettings coreSettings) {
 		coreSettings.setConcurrentCoreCount(preferences.getInt(PARALLEL_CORES));
+		InfinitestGlobalSettings.setDisableWhenWorkspaceHasErrors(preferences.getBoolean(DISABLE_WHEN_WORKSPACE_HAS_ERRORS));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
 		ColorSettings.setFailingBackgroundColor(preferences.getInt(PreferencesConstants.FAILING_BACKGROUND_COLOR));
 		ColorSettings.setFailngTextColor(preferences.getInt(PreferencesConstants.FAILING_TEXT_COLOR));

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -125,6 +125,6 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 		InfinitestGlobalSettings.setDisableWhenWorkspaceHasErrors(preferences.getBoolean(DISABLE_WHEN_WORKSPACE_HAS_ERRORS));
 		InfinitestGlobalSettings.setSlowTestTimeLimit(preferences.getLong(SLOW_TEST_WARNING));
 		ColorSettings.setFailingBackgroundColor(preferences.getInt(PreferencesConstants.FAILING_BACKGROUND_COLOR));
-		ColorSettings.setFailngTextColor(preferences.getInt(PreferencesConstants.FAILING_TEXT_COLOR));
+		ColorSettings.setFailingTextColor(preferences.getInt(PreferencesConstants.FAILING_TEXT_COLOR));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/InfinitestPlugin.java
@@ -100,6 +100,7 @@ public class InfinitestPlugin extends AbstractUIPlugin {
 	@Override
 	protected void initializeDefaultPreferences(IPreferenceStore store) {
 		store.setDefault(PARALLEL_CORES, 1);
+		store.setDefault(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, true);
 		store.setDefault(SLOW_TEST_WARNING, getSlowTestTimeLimit());
 		store.setDefault(FAILING_BACKGROUND_COLOR, ColorSettings.getFailingBackgroundColor());
 		store.setDefault(FAILING_TEXT_COLOR, ColorSettings.getFailingTextColor());

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
@@ -39,7 +39,6 @@ import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.swt.SWT;
 import org.infinitest.eclipse.InfinitestPlugin;
-import org.infinitest.eclipse.trim.ColorSettings;
 
 public class InfinitestPreferenceInitializer extends AbstractPreferenceInitializer {
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
@@ -37,6 +37,7 @@ import static org.infinitest.util.InfinitestGlobalSettings.getSlowTestTimeLimit;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.swt.SWT;
 import org.infinitest.eclipse.InfinitestPlugin;
 import org.infinitest.eclipse.trim.ColorSettings;
 
@@ -53,7 +54,7 @@ public class InfinitestPreferenceInitializer extends AbstractPreferenceInitializ
 		node.put(PARALLEL_CORES, Integer.toString(1));
 		node.put(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, Boolean.toString(false));
 		node.put(SLOW_TEST_WARNING, Long.toString(getSlowTestTimeLimit()));
-		node.put(FAILING_BACKGROUND_COLOR, Integer.toString(ColorSettings.getFailingBackgroundColor()));
-		node.put(FAILING_TEXT_COLOR, Integer.toString(ColorSettings.getFailingTextColor()));
+		node.put(FAILING_BACKGROUND_COLOR, Integer.toString(SWT.COLOR_DARK_RED));
+		node.put(FAILING_TEXT_COLOR, Integer.toString(SWT.COLOR_WHITE));
 	}
 }

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
@@ -1,0 +1,59 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.eclipse.prefs;
+
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
+import static org.infinitest.util.InfinitestGlobalSettings.getSlowTestTimeLimit;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.infinitest.eclipse.InfinitestPlugin;
+import org.infinitest.eclipse.trim.ColorSettings;
+
+public class InfinitestPreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		IEclipsePreferences node = new DefaultScope().getNode(InfinitestPlugin.PLUGIN_ID);
+		
+		initializePreferenceNodeWithDefaults(node);
+	}
+
+	public void initializePreferenceNodeWithDefaults(IEclipsePreferences node) {
+		node.put(PARALLEL_CORES, Integer.toString(1));
+		node.put(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, Boolean.toString(false));
+		node.put(SLOW_TEST_WARNING, Long.toString(getSlowTestTimeLimit()));
+		node.put(FAILING_BACKGROUND_COLOR, Integer.toString(ColorSettings.getFailingBackgroundColor()));
+		node.put(FAILING_TEXT_COLOR, Integer.toString(ColorSettings.getFailingTextColor()));
+	}
+}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -31,6 +31,7 @@ import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.eclipse.jface.preference.FieldEditor.VALUE;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.AUTO_TEST;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILED_TEST_MARKER_SEVERITY;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
@@ -46,6 +47,7 @@ import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
 import org.infinitest.eclipse.markers.SlowMarkerRegistry;
 import org.infinitest.eclipse.trim.ColorSettings;
 import org.infinitest.eclipse.workspace.CoreSettings;
+import org.infinitest.util.InfinitestGlobalSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -69,6 +71,8 @@ public class PreferenceChangeHandler {
 		
 		if (AUTO_TEST.equals(preference)) {
 			updateAutoTest((Boolean) newValue);
+		} else if (DISABLE_WHEN_WORKSPACE_HAS_ERRORS.equals(preference)) {
+			updateDisableWhenWorkspaceHasErrors((Boolean) newValue);
 		} else if (SLOW_TEST_WARNING.equals(preference)) {
 			updateSlowTestWarning((String) newValue);
 		} else if (PARALLEL_CORES.equals(preference)) {
@@ -113,6 +117,10 @@ public class PreferenceChangeHandler {
 		} else {
 			controller.disable();
 		}
+	}
+	
+	private void updateDisableWhenWorkspaceHasErrors(boolean newValue) {
+		InfinitestGlobalSettings.setDisableWhenWorkspaceHasErrors(newValue);
 	}
 
 	private void updateFailedTestMarkerSeverity(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferenceChangeHandler.java
@@ -89,7 +89,7 @@ public class PreferenceChangeHandler {
 	}
 
 	private void updateFailingTextColor(String newValue) {
-		ColorSettings.setFailngTextColor(Integer.valueOf(newValue));
+		ColorSettings.setFailingTextColor(Integer.valueOf(newValue));
 	}
 
 	private void updateFailingBackgroundColor(String newValue) {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencePage.java
@@ -29,6 +29,7 @@ package org.infinitest.eclipse.prefs;
 
 import static java.lang.Integer.MAX_VALUE;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.AUTO_TEST;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
 
@@ -75,6 +76,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	@Override
 	protected void createFieldEditors() {
 		addField(createAutoTestEditor());
+		addField(createDisableWhenWorkspaceHasErrorsEditor());
 		addField(createParallelizationEditor());
 		addField(createSlowTestWarningCutoffEditor());
 		addField(createSeverityEditor(PreferencesConstants.FAILED_TEST_MARKER_SEVERITY, "Failed test severity"));
@@ -85,6 +87,10 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 
 	private BooleanFieldEditor createAutoTestEditor() {
 		return new BooleanFieldEditor(AUTO_TEST, "Continuously Test", getFieldEditorParent());
+	}
+
+	private BooleanFieldEditor createDisableWhenWorkspaceHasErrorsEditor() {
+		return new BooleanFieldEditor(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, "Disable when workspace has errors", getFieldEditorParent());
 	}
 
 	private SwtColorFieldEditor createFailingBackgroundColorEditor() {

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/PreferencesConstants.java
@@ -32,6 +32,8 @@ public abstract class PreferencesConstants {
 	 * Indicates if Infinitest should automatically be run.
 	 */
 	public static final String AUTO_TEST = "org.infinitest.eclipse.auto";
+	
+	public static final String DISABLE_WHEN_WORKSPACE_HAS_ERRORS = "org.infinitest.eclipse.disable.when.project.has.errors";
 
 	public static final String LICENSE_KEY = "org.infinitest.eclipse.license.key";
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/trim/ColorSettings.java
@@ -40,7 +40,7 @@ public class ColorSettings {
 		return failingTextColor;
 	}
 
-	public static void setFailngTextColor(int failTextColor) {
+	public static void setFailingTextColor(int failTextColor) {
 		ColorSettings.failingTextColor = failTextColor;
 	}
 

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/workspace/EclipseWorkspace.java
@@ -54,6 +54,7 @@ import org.infinitest.eclipse.status.WorkspaceStatusListener;
 import org.infinitest.environment.RuntimeEnvironment;
 import org.infinitest.parser.JavaClass;
 import org.infinitest.util.Events;
+import org.infinitest.util.InfinitestGlobalSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -85,7 +86,7 @@ class EclipseWorkspace implements WorkspaceFacade {
 
 	@Override
 	public void updateProjects(Set<IResource> modifiedResources) throws CoreException {
-		if (projectSet.hasErrors()) {
+		if (projectSet.hasErrors() && InfinitestGlobalSettings.isDisableWhenWorkspaceHasErrors()) {
 			setStatus(workspaceErrors());
 		} else {
 			int numberOfTestsToRun = updateProjectsIn(modifiedResources);
@@ -142,7 +143,7 @@ class EclipseWorkspace implements WorkspaceFacade {
 		return totalTests;
 	}
 
-	private int updateProject(ProjectFacade project, Collection<File> changedFiles) throws CoreException {
+	protected int updateProject(ProjectFacade project, Collection<File> changedFiles) throws CoreException {
 		RuntimeEnvironment environment = buildRuntimeEnvironment(project);
 		InfinitestCore core = coreRegistry.getCore(project.getLocationURI());
 		if (core == null) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializerTest.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest.eclipse.prefs;
+
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROUND_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.swt.SWT;
+import org.junit.jupiter.api.Test;
+
+class InfinitestPreferenceInitializerTest {
+
+	@Test
+	void initializePreferenceNodeWithDefaults() {
+		IEclipsePreferences node = mock(IEclipsePreferences.class);
+		InfinitestPreferenceInitializer initializer = new InfinitestPreferenceInitializer();
+		
+		initializer.initializePreferenceNodeWithDefaults(node);
+		
+		verify(node, times(1)).put(PARALLEL_CORES, "1");
+		verify(node, times(1)).put(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, "false");
+		verify(node, times(1)).put(SLOW_TEST_WARNING, "500");
+		verify(node, times(1)).put(FAILING_BACKGROUND_COLOR, Integer.toString(SWT.COLOR_DARK_RED));
+		verify(node, times(1)).put(FAILING_TEXT_COLOR, Integer.toString(SWT.COLOR_WHITE));
+	}
+}

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/prefs/WhenPreferencesAreChanged.java
@@ -27,21 +27,35 @@
  */
 package org.infinitest.eclipse.prefs;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.core.resources.IMarker.SEVERITY_WARNING;
-import static org.eclipse.jface.preference.FieldEditor.*;
-import static org.infinitest.eclipse.prefs.PreferencesConstants.*;
-import static org.infinitest.util.InfinitestGlobalSettings.*;
+import static org.eclipse.jface.preference.FieldEditor.IS_VALID;
+import static org.eclipse.jface.preference.FieldEditor.VALUE;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.AUTO_TEST;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.DISABLE_WHEN_WORKSPACE_HAS_ERRORS;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILED_TEST_MARKER_SEVERITY;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_MARKER_SEVERITY;
+import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
+import static org.infinitest.util.InfinitestGlobalSettings.getSlowTestTimeLimit;
+import static org.infinitest.util.InfinitestGlobalSettings.resetToDefaults;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
-import org.eclipse.jface.preference.*;
-import org.eclipse.jface.util.*;
-import org.eclipse.swt.*;
-import org.infinitest.eclipse.*;
-import org.infinitest.eclipse.markers.*;
-import org.infinitest.eclipse.trim.*;
-import org.infinitest.eclipse.workspace.*;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.swt.SWT;
+import org.infinitest.eclipse.PluginActivationController;
+import org.infinitest.eclipse.markers.ProblemMarkerRegistry;
+import org.infinitest.eclipse.markers.SlowMarkerRegistry;
+import org.infinitest.eclipse.trim.ColorSettings;
+import org.infinitest.eclipse.workspace.CoreSettings;
+import org.infinitest.util.InfinitestGlobalSettings;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,6 +170,17 @@ class WhenPreferencesAreChanged {
 	void shouldIgnoreBlankValues() {
 		when(eventSource.getPreferenceName()).thenReturn(PARALLEL_CORES);
 		assertDoesNotThrow(() -> changeProperty(VALUE, "", ""));
+	}
+	
+	@Test
+	void updateDisableWhenWorkspaceHasErrors() {
+		when(eventSource.getPreferenceName()).thenReturn(DISABLE_WHEN_WORKSPACE_HAS_ERRORS);
+		
+		changeProperty(VALUE, true, false);
+		assertThat(InfinitestGlobalSettings.isDisableWhenWorkspaceHasErrors()).isFalse();
+		
+		changeProperty(VALUE, false, true);
+		assertThat(InfinitestGlobalSettings.isDisableWhenWorkspaceHasErrors()).isTrue();
 	}
 
 	private void changeProperty(String type, Object oldValue, Object newValue) {

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/trim/WhenShowingStatusInTheStatusBar.java
@@ -46,10 +46,12 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 
+import org.eclipse.swt.SWT;
 import org.infinitest.TestQueueEvent;
 import org.infinitest.eclipse.status.WorkspaceStatus;
 import org.infinitest.testrunner.TestCaseEvent;
 import org.infinitest.testrunner.TestResults;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -64,6 +66,12 @@ class WhenShowingStatusInTheStatusBar {
 		presenter = new VisualStatusPresenter();
 		presenter.updateVisualStatus(statusBar);
 		firstEvent = new TestQueueEvent(asList("ATest"), 2);
+	}
+	
+	@AfterAll
+	public static void resetDefaults() {
+		ColorSettings.setFailingBackgroundColor(SWT.COLOR_DARK_RED);
+		ColorSettings.setFailingTextColor(SWT.COLOR_WHITE);
 	}
 
 	@Test
@@ -124,7 +132,7 @@ class WhenShowingStatusInTheStatusBar {
 	@Test
 	void shouldChangeToFailingBackgroundColorWhenTestsFail() {
 		ColorSettings.setFailingBackgroundColor(COLOR_DARK_RED);
-		ColorSettings.setFailngTextColor(COLOR_YELLOW);
+		ColorSettings.setFailingTextColor(COLOR_YELLOW);
 
 		presenter.coreStatusChanged(PASSING, FAILING);
 

--- a/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
@@ -27,9 +27,9 @@
  */
 package org.infinitest.util;
 
-import static java.util.logging.Level.*;
+import static java.util.logging.Level.INFO;
 
-import java.util.logging.*;
+import java.util.logging.Level;
 
 /**
  * @author <a href="mailto:benrady@gmail.com"Ben Rady</a>
@@ -37,6 +37,7 @@ import java.util.logging.*;
 public class InfinitestGlobalSettings {
 	private static Level logLevel = Level.INFO;
 	private static long slowTestTimeLimit = 500;
+	private static boolean disableWhenWorkspaceHasErrors;
 
 	public static void resetToDefaults() {
 		setLogLevel(INFO);
@@ -57,5 +58,13 @@ public class InfinitestGlobalSettings {
 
 	public static long getSlowTestTimeLimit() {
 		return slowTestTimeLimit;
+	}
+
+	public static boolean isDisableWhenWorkspaceHasErrors() {
+		return disableWhenWorkspaceHasErrors;
+	}
+
+	public static void setDisableWhenWorkspaceHasErrors(boolean disableWhenWorkspaceHasErrors) {
+		InfinitestGlobalSettings.disableWhenWorkspaceHasErrors = disableWhenWorkspaceHasErrors;
 	}
 }

--- a/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 public class InfinitestGlobalSettings {
 	private static Level logLevel = Level.INFO;
 	private static long slowTestTimeLimit = 500;
-	private static boolean disableWhenWorkspaceHasErrors;
+	private static boolean disableWhenWorkspaceHasErrors = true;
 
 	public static void resetToDefaults() {
 		setLogLevel(INFO);


### PR DESCRIPTION
When there's a single error in an Eclipse workspace Infinitest stops running tests even if the error might be in an unrelated project.
Added an option to let Infinitest run tests in that case.

Fixes #65 