### PR TITLE
fix: harcode the slow test default limit

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/prefs/InfinitestPreferenceInitializer.java
@@ -32,7 +32,7 @@ import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_BACKGROU
 import static org.infinitest.eclipse.prefs.PreferencesConstants.FAILING_TEXT_COLOR;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.PARALLEL_CORES;
 import static org.infinitest.eclipse.prefs.PreferencesConstants.SLOW_TEST_WARNING;
-import static org.infinitest.util.InfinitestGlobalSettings.getSlowTestTimeLimit;
+import static org.infinitest.util.InfinitestGlobalSettings.DEFAULT_SLOW_TEST_LIMIT;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
@@ -52,7 +52,7 @@ public class InfinitestPreferenceInitializer extends AbstractPreferenceInitializ
 	public void initializePreferenceNodeWithDefaults(IEclipsePreferences node) {
 		node.put(PARALLEL_CORES, Integer.toString(1));
 		node.put(DISABLE_WHEN_WORKSPACE_HAS_ERRORS, Boolean.toString(false));
-		node.put(SLOW_TEST_WARNING, Long.toString(getSlowTestTimeLimit()));
+		node.put(SLOW_TEST_WARNING, Long.toString(DEFAULT_SLOW_TEST_LIMIT));
 		node.put(FAILING_BACKGROUND_COLOR, Integer.toString(SWT.COLOR_DARK_RED));
 		node.put(FAILING_TEXT_COLOR, Integer.toString(SWT.COLOR_WHITE));
 	}

--- a/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
+++ b/infinitest-lib/src/main/java/org/infinitest/util/InfinitestGlobalSettings.java
@@ -34,10 +34,15 @@ import java.util.logging.Level;
 /**
  * @author <a href="mailto:benrady@gmail.com"Ben Rady</a>
  */
-public class InfinitestGlobalSettings {
+public final class InfinitestGlobalSettings {
+	public static final int DEFAULT_SLOW_TEST_LIMIT = 500;
+	
 	private static Level logLevel = Level.INFO;
-	private static long slowTestTimeLimit = 500;
+	private static long slowTestTimeLimit = DEFAULT_SLOW_TEST_LIMIT;
 	private static boolean disableWhenWorkspaceHasErrors = true;
+	
+	private InfinitestGlobalSettings() {
+	}
 
 	public static void resetToDefaults() {
 		setLogLevel(INFO);


### PR DESCRIPTION
The slow test limit is not final and might change, for instance Infinitest's own tests change it so InfinitestPreferenceInitializerTest might fail depending on the order of the test