### PR TITLE
fix: stop using project components and constructor injection

### DIFF
--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/language/InfinitestHighlightingPassFactory.java
@@ -36,6 +36,7 @@ import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiFile;
 
@@ -44,8 +45,9 @@ public class InfinitestHighlightingPassFactory implements TextEditorHighlighting
 	 * The key to retrieve the {@link InfinitestLineMarkersPass} in the {@link Editor}
 	 */
 	public static final Key<InfinitestLineMarkersPass> KEY = new Key<>("InfinitestLineMarkersPass");
-
-	public InfinitestHighlightingPassFactory(TextEditorHighlightingPassRegistrar passRegistrar) {
+	
+	public InfinitestHighlightingPassFactory(Project project) {
+		TextEditorHighlightingPassRegistrar passRegistrar = TextEditorHighlightingPassRegistrar.getInstance(project);
 		passRegistrar.registerTextEditorHighlightingPass(this, TextEditorHighlightingPassRegistrar.Anchor.LAST, Pass.UPDATE_ALL, true, true);
 	}
 

--- a/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/window/InfinitestToolWindowFactory.java
+++ b/infinitest-intellij/src/main/java/org/infinitest/intellij/idea/window/InfinitestToolWindowFactory.java
@@ -33,6 +33,7 @@ import org.infinitest.intellij.InfinitestIcons;
 import org.infinitest.intellij.InfinitestLoggingListener;
 import org.infinitest.intellij.InfinitestTopics;
 import org.infinitest.intellij.idea.IdeaSourceNavigator;
+import org.infinitest.intellij.idea.language.InfinitestHighlightingPassFactory;
 import org.infinitest.intellij.plugin.launcher.FileEditorListener;
 import org.infinitest.intellij.plugin.launcher.InfinitestPresenter;
 import org.infinitest.intellij.plugin.swingui.InfinitestMainFrame;
@@ -95,6 +96,7 @@ public class InfinitestToolWindowFactory implements ToolWindowFactory {
 		projectMessageBusConnection.subscribe(ProjectTopics.MODULES, treeModelAdapter);
 		projectMessageBusConnection.subscribe(ProjectTopics.PROJECT_ROOTS, treeModelAdapter);
 
+		new InfinitestHighlightingPassFactory(project);
 		new InfinitestPresenter(project, frame);
 		
 		// TODO replace by something not static

--- a/infinitest-intellij/src/main/resources/META-INF/plugin.xml
+++ b/infinitest-intellij/src/main/resources/META-INF/plugin.xml
@@ -31,12 +31,6 @@
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
     
-    <project-components>
-        <component>
-            <implementation-class>org.infinitest.intellij.idea.language.InfinitestHighlightingPassFactory</implementation-class>
-        </component>
-    </project-components>
-    
     <projectListeners>
     	<listener class="org.infinitest.intellij.idea.IdeaCompilationListener" topic="com.intellij.task.ProjectTaskListener"/>
         <listener class="org.infinitest.intellij.idea.FilterFileWatcher" topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -44,6 +44,7 @@ import org.infinitest.intellij.plugin.launcher.InfinitestLauncher;
 import org.infinitest.testrunner.TestResultsListener;
 import org.junit.jupiter.api.BeforeEach;
 
+import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.ui.ConsoleView;
@@ -80,6 +81,7 @@ public class IntellijMockBase {
 	protected MessageBusConnection messageBusConnection;
 	protected ProjectFileIndex projectFileIndex;
 	protected ProjectRootManager projectRootManager; 
+	protected TextEditorHighlightingPassRegistrar passRegistrar;
 	
 	protected InfinitestLauncher launcher;
 	protected ModuleSettings moduleSettings;
@@ -97,6 +99,8 @@ public class IntellijMockBase {
 		messageBusConnection = mock(MessageBusConnection.class);
 		projectFileIndex = mock(ProjectFileIndex.class);
 		projectRootManager = mock(ProjectRootManager.class);
+		passRegistrar = mock(TextEditorHighlightingPassRegistrar.class);
+		
 		launcher = mock(InfinitestLauncher.class);
 		moduleSettings = mock(ModuleSettings.class);
 		runtimeEnvironment = mock(RuntimeEnvironment.class);
@@ -111,6 +115,7 @@ public class IntellijMockBase {
 		when(project.getService(InfinitestAnnotator.class)).thenReturn(annotator);
 		when(project.getService(ProjectFileIndex.class)).thenReturn(projectFileIndex);
 		when(project.getService(ProjectRootManager.class)).thenReturn(projectRootManager);
+		when(project.getService(TextEditorHighlightingPassRegistrar.class)).thenReturn(passRegistrar);
 		
 		when(module.getName()).thenReturn("module");
 		when(module.getProject()).thenReturn(project);


### PR DESCRIPTION
InfinitestHighlightingPassFactory is declared as a project component and these should be migrated to services. The Jetbrains marketplace flagged that it uses constructor injection and refused the new version of the plugin.
Since we need it to register from somewhere, create it in the InfinitestToolWindowFactory

Fixes #401 