### PR TITLE
fix: remove slow test markers for removed/disabled tests

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
@@ -49,28 +49,22 @@ public class SlowTestObserver implements DisabledTestListener, TestResultsListen
 		this.lookup = lookup;
 	}
 
-	private void runStatsUpdated(String testName, MethodStats newStats) {
-		// DEBT This class wants to share a lot of code with ResultCollector
-		// The whole process of detecting passing/failing/ignored/disabled tests
-		// is remarkably
-		// similar to the process of detecting slow/fast/ignored/disabled tests.
-		SlowTestMarkerInfo marker = new SlowTestMarkerInfo(testName, newStats, lookup, slowMarkerRegistry.markerServerity());
-		if (newStats.duration() > getSlowTestTimeLimit()) {
-			slowMarkerRegistry.addMarker(marker);
-		} else {
-			slowMarkerRegistry.removeMarker(marker);
-		}
-	}
-
 	@Override
 	public void testCaseStarting(TestEvent event) {
 	}
 
 	@Override
 	public void testCaseComplete(TestCaseEvent event) {
+		Collection<MarkerInfo> markers = new ArrayList<>();
+		
 		for (MethodStats methodStat : event.getRunStats()) {
-			runStatsUpdated(event.getTestName(), methodStat);
+			if (methodStat.duration() > getSlowTestTimeLimit()) {
+				SlowTestMarkerInfo marker = new SlowTestMarkerInfo(event.getTestName(), methodStat, lookup, slowMarkerRegistry.markerServerity());
+				markers.add(marker);
+			}
 		}
+		
+		slowMarkerRegistry.setMarkers(event.getTestName(), markers);
 	}
 
 	@Override

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/SlowTestObserver.java
@@ -49,6 +49,11 @@ public class SlowTestObserver implements DisabledTestListener, TestResultsListen
 		this.lookup = lookup;
 	}
 
+		// DEBT This class wants to share a lot of code with ResultCollector
+		// The whole process of detecting passing/failing/ignored/disabled tests
+		// is remarkably
+		// similar to the process of detecting slow/fast/ignored/disabled tests.
+
 	@Override
 	public void testCaseStarting(TestEvent event) {
 	}

--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/GenericMarkerRegistry.java
@@ -30,6 +30,7 @@ package org.infinitest.eclipse.markers;
 import static org.infinitest.util.InfinitestUtils.log;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -136,6 +137,25 @@ public class GenericMarkerRegistry implements MarkerRegistry {
 	public void removeMarkers(String testName) {
 		for (MarkerInfo each : findMarkersFor(testName)) {
 			deleteMarker(each);
+		}
+	}
+	
+	@Override
+	public void setMarkers(String testName, Collection<MarkerInfo> markers) {
+		Collection<MarkerInfo> markersToProcess = new HashSet<>(markers);
+		
+		// Update the current markers
+		for (MarkerInfo marker : findMarkersFor(testName)) {
+			if (markersToProcess.contains(marker)) {
+				updateMarker(marker);
+				markersToProcess.remove(marker);
+			} else {
+				removeMarker(marker);
+			}
+		}
+		// Add the new markers
+		for (MarkerInfo marker : markersToProcess) {
+			addMarker(marker);
 		}
 	}
 

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/WhenWatchingForSlowTests.java
@@ -40,6 +40,7 @@ import org.infinitest.testrunner.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 
 class WhenWatchingForSlowTests {
 	private SlowMarkerRegistry mockMarkerRegistry;
@@ -74,7 +75,7 @@ class WhenWatchingForSlowTests {
 
 		observer.testCaseComplete(event);
 
-		verify(mockMarkerRegistry).addMarker(expectedMarker);
+		verify(mockMarkerRegistry).setMarkers(eq("MyTest"), eq(Arrays.asList(expectedMarker)));
 	}
 
 	@Test
@@ -84,7 +85,7 @@ class WhenWatchingForSlowTests {
 
 		observer.testCaseComplete(event);
 
-		verify(mockMarkerRegistry).removeMarker(expectedMarker);
+		verify(mockMarkerRegistry).setMarkers(eq("MyTest"), emptyCollection());
 	}
 
 	@Test
@@ -95,8 +96,18 @@ class WhenWatchingForSlowTests {
 		observer.testCaseComplete(event);
 		observer.testsDisabled(Arrays.asList("MyTest"));
 
-		verify(mockMarkerRegistry).addMarker(expectedMarker);
+		verify(mockMarkerRegistry).setMarkers(eq("MyTest"), eq(Arrays.asList(expectedMarker)));
 		verify(mockMarkerRegistry).removeMarkers("MyTest");
+	}
+
+	@Test
+	void shouldRemoveMarkersWhenTestsAreIgnored() {
+		TestResults ignoreTestResults = new TestResults(Collections.emptyList());
+		TestCaseEvent ignoredTestEvent = new TestCaseEvent("MyTest", this, ignoreTestResults);
+		
+		observer.testCaseComplete(ignoredTestEvent);
+
+		verify(mockMarkerRegistry).setMarkers(eq("MyTest"), emptyCollection());
 	}
 
 	@Test
@@ -104,5 +115,10 @@ class WhenWatchingForSlowTests {
 		observer.clearMarkers();
 
 		verify(mockMarkerRegistry).clear();
+	}
+	
+	private static <T> Collection<T> emptyCollection() {
+		ArgumentMatcher<Collection<T>> matcher = c -> c.isEmpty();
+		return argThat(matcher);
 	}
 }

--- a/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
+++ b/infinitest-eclipse/src/test/java/org/infinitest/eclipse/markers/WhenCreatingMarkers.java
@@ -41,6 +41,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.core.commands.ExecutionException;
@@ -53,6 +55,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class WhenCreatingMarkers {
+	private static final String TEST_NAME = "com.fake.TestName";
 	private GenericMarkerRegistry registry;
 	private AssertionError error;
 	private UpdateMarkersOperation updateMarkersOperation;
@@ -162,7 +165,7 @@ class WhenCreatingMarkers {
 		registry.removeMarkers("NotATest");
 		assertThat(registry.getMarkers()).isNotEmpty();
 
-		registry.removeMarkers("com.fake.TestName");
+		registry.removeMarkers(TEST_NAME);
 		assertThat(registry.getMarkers()).isEmpty();
 	}
 
@@ -186,12 +189,28 @@ class WhenCreatingMarkers {
 		
 		assertEquals(SEVERITY_INFO, registry.markerServerity());
 	}
+	
+	@Test
+	void setMarkersOverwritesExistingMarkers() {
+		// add some markers
+		addMarker(methodFailed("", TEST_NAME, "methodName1", error));
+		addMarker(methodFailed("", TEST_NAME, "methodName2", error));
+		
+		// now set these two markers
+		FakeProblemMarkerInfo marker1 = new FakeProblemMarkerInfo(methodFailed("", TEST_NAME, "methodName1", error));
+		FakeProblemMarkerInfo marker3 = new FakeProblemMarkerInfo(methodFailed("", TEST_NAME, "methodName3", error));
+		Collection<MarkerInfo> markers = Arrays.asList(marker1, marker3);
+		
+		registry.setMarkers(TEST_NAME, markers);
+		
+		assertThat(registry.getMarkers()).containsExactlyInAnyOrder(marker1, marker3);
+	}
 
 	private void addMarker(TestEvent event) {
 		registry.addMarker(new FakeProblemMarkerInfo(event));
 	}
 
 	private TestEvent failureEvent(String failureMessage) {
-		return methodFailed(failureMessage, "com.fake.TestName", "methodName", error);
+		return methodFailed(failureMessage, TEST_NAME, "methodName", error);
 	}
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledClassJUnit5TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledClassJUnit5TestCase.java
@@ -25,36 +25,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.eclipse.markers;
+package com.fakeco.fakeproduct;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import org.eclipse.core.resources.IMarker;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public interface MarkerRegistry {
-	void addMarker(MarkerInfo marker);
+/**
+ * Created by fpoyer on 28/06/17.
+ */
+@Disabled
+public class DisabledClassJUnit5TestCase {
 
-	void removeMarker(MarkerInfo marker);
-
-	void clear();
-
-	void updateMarker(MarkerInfo marker);
-
-	void removeMarkers(String testName);
-	
-	/**
-	 * Set the markers for a given test name. For instance if the collection is empty all the markers will be cleared for that test
-	 * 
-	 * @param testName The test name
-	 * @param markers The new collection of markers
-	 */
-	void setMarkers(String testName, Collection<MarkerInfo> markers);
-
-	/**
-	 * Updates the severity of all the markers
-	 * @param markersSeverity The new marker severity, for instance {@link IMarker#SEVERITY_ERROR}
-	 */
-	void updateMarkersSeverity(int markersSeverity);
-	
-	int markerServerity();
+    @Test
+    void nonPublicJUnit5TestShouldPass() {
+        assertThat(true).isTrue();
+    }
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledClassJUnit5TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledClassJUnit5TestCase.java
@@ -35,11 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by fpoyer on 28/06/17.
  */
-@Disabled
+@Disabled(value = "should be considered as a test")
 public class DisabledClassJUnit5TestCase {
 
-    @Test
-    void nonPublicJUnit5TestShouldPass() {
-        assertThat(true).isTrue();
-    }
+	@Test
+	void nonPublicJUnit5TestShouldPass() {
+		assertThat(isTrue()).isTrue();
+	}
+
+	private boolean isTrue() {
+		return true;
+	}
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledTestJUnit5TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledTestJUnit5TestCase.java
@@ -25,36 +25,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.eclipse.markers;
+package com.fakeco.fakeproduct;
 
-import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import org.eclipse.core.resources.IMarker;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public interface MarkerRegistry {
-	void addMarker(MarkerInfo marker);
+/**
+ * Created by fpoyer on 28/06/17.
+ */
+public class DisabledTestJUnit5TestCase {
 
-	void removeMarker(MarkerInfo marker);
-
-	void clear();
-
-	void updateMarker(MarkerInfo marker);
-
-	void removeMarkers(String testName);
-	
-	/**
-	 * Set the markers for a given test name. For instance if the collection is empty all the markers will be cleared for that test
-	 * 
-	 * @param testName The test name
-	 * @param markers The new collection of markers
-	 */
-	void setMarkers(String testName, Collection<MarkerInfo> markers);
-
-	/**
-	 * Updates the severity of all the markers
-	 * @param markersSeverity The new marker severity, for instance {@link IMarker#SEVERITY_ERROR}
-	 */
-	void updateMarkersSeverity(int markersSeverity);
-	
-	int markerServerity();
+    @Test
+    @Disabled
+    void nonPublicJUnit5TestShouldPass() {
+        assertThat(true).isTrue();
+    }
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledTestJUnit5TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/DisabledTestJUnit5TestCase.java
@@ -37,9 +37,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class DisabledTestJUnit5TestCase {
 
-    @Test
-    @Disabled
-    void nonPublicJUnit5TestShouldPass() {
-        assertThat(true).isTrue();
-    }
+	@Test
+	@Disabled(value = "should be considered as a test")
+	void nonPublicJUnit5TestShouldPass() {
+		assertThat(isTrue()).isTrue();
+	}
+
+	private boolean isTrue() {
+		return true;
+	}
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredClassJUnit4TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredClassJUnit4TestCase.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.*;
 
 import org.junit.*;
 
-@Ignore
+@Ignore(value = "should be considered as a test")
 public class IgnoredClassJUnit4TestCase {
 	private static final String KEY = IgnoredClassJUnit4TestCase.class.getName() + "TOGGLE";
 	private static final String ENABLED = "ENABLED";

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredClassJUnit4TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredClassJUnit4TestCase.java
@@ -25,36 +25,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.eclipse.markers;
+package com.fakeco.fakeproduct;
 
-import java.util.Collection;
+import static org.junit.Assert.*;
 
-import org.eclipse.core.resources.IMarker;
+import org.junit.*;
 
-public interface MarkerRegistry {
-	void addMarker(MarkerInfo marker);
+@Ignore
+public class IgnoredClassJUnit4TestCase {
+	private static final String KEY = IgnoredClassJUnit4TestCase.class.getName() + "TOGGLE";
+	private static final String ENABLED = "ENABLED";
 
-	void removeMarker(MarkerInfo marker);
+	@Test
+	@SuppressWarnings("all")
+	public void shouldPass() {
+	}
 
-	void clear();
+	@Test
+	public void shouldFailIfPropertyIsSet() {
+		if (ENABLED.equals(System.getProperty(KEY))) {
+			fail("Test Failed");
+		}
+	}
 
-	void updateMarker(MarkerInfo marker);
+	public static void enable() {
+		System.setProperty(KEY, ENABLED);
+	}
 
-	void removeMarkers(String testName);
-	
-	/**
-	 * Set the markers for a given test name. For instance if the collection is empty all the markers will be cleared for that test
-	 * 
-	 * @param testName The test name
-	 * @param markers The new collection of markers
-	 */
-	void setMarkers(String testName, Collection<MarkerInfo> markers);
-
-	/**
-	 * Updates the severity of all the markers
-	 * @param markersSeverity The new marker severity, for instance {@link IMarker#SEVERITY_ERROR}
-	 */
-	void updateMarkersSeverity(int markersSeverity);
-	
-	int markerServerity();
+	public static void disable() {
+		System.clearProperty(KEY);
+	}
 }

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredTestJUnit4TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredTestJUnit4TestCase.java
@@ -35,13 +35,13 @@ public class IgnoredTestJUnit4TestCase {
 	private static final String KEY = IgnoredTestJUnit4TestCase.class.getName() + "TOGGLE";
 	private static final String ENABLED = "ENABLED";
 
-	@Ignore
+	@Ignore(value = "should be considered as a test")
 	@Test
 	@SuppressWarnings("all")
 	public void shouldPass() {
 	}
 
-	@Ignore
+	@Ignore(value = "should be considered as a test")
 	@Test
 	public void shouldFailIfPropertyIsSet() {
 		if (ENABLED.equals(System.getProperty(KEY))) {

--- a/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredTestJUnit4TestCase.java
+++ b/infinitest-lib/src/test/java/com/fakeco/fakeproduct/IgnoredTestJUnit4TestCase.java
@@ -25,36 +25,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.infinitest.eclipse.markers;
+package com.fakeco.fakeproduct;
 
-import java.util.Collection;
+import static org.junit.Assert.*;
 
-import org.eclipse.core.resources.IMarker;
+import org.junit.*;
 
-public interface MarkerRegistry {
-	void addMarker(MarkerInfo marker);
+public class IgnoredTestJUnit4TestCase {
+	private static final String KEY = IgnoredTestJUnit4TestCase.class.getName() + "TOGGLE";
+	private static final String ENABLED = "ENABLED";
 
-	void removeMarker(MarkerInfo marker);
+	@Ignore
+	@Test
+	@SuppressWarnings("all")
+	public void shouldPass() {
+	}
 
-	void clear();
+	@Ignore
+	@Test
+	public void shouldFailIfPropertyIsSet() {
+		if (ENABLED.equals(System.getProperty(KEY))) {
+			fail("Test Failed");
+		}
+	}
 
-	void updateMarker(MarkerInfo marker);
+	public static void enable() {
+		System.setProperty(KEY, ENABLED);
+	}
 
-	void removeMarkers(String testName);
-	
-	/**
-	 * Set the markers for a given test name. For instance if the collection is empty all the markers will be cleared for that test
-	 * 
-	 * @param testName The test name
-	 * @param markers The new collection of markers
-	 */
-	void setMarkers(String testName, Collection<MarkerInfo> markers);
-
-	/**
-	 * Updates the severity of all the markers
-	 * @param markersSeverity The new marker severity, for instance {@link IMarker#SEVERITY_ERROR}
-	 */
-	void updateMarkersSeverity(int markersSeverity);
-	
-	int markerServerity();
+	public static void disable() {
+		System.clearProperty(KEY);
+	}
 }

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
@@ -71,7 +71,7 @@ class JavaAssistClassTestDetectionTest {
 		assertThat(classPoolUtil.getClass(TestNGFakeProductTest.class).isATest()).isTrue();
 		assertThat(classPoolUtil.getClass(TestNGWithClassLevelOnlyTestAnnotationFakeTest.class).isATest()).isTrue();
 		
-		// Ignored/disabled tests are still considered as tests, we leave it to the test engine to decide if a test much run
+		// Ignored/disabled tests are still considered as tests, we leave it to the test engine to decide if a test must run
 		// We cannot always evaluate conditions (for instance @DisabledForJreRange)t
 		assertThat(classPoolUtil.getClass(IgnoredClassJUnit4TestCase.class).isATest()).isFalse();
 		assertThat(classPoolUtil.getClass(IgnoredTestJUnit4TestCase.class).isATest()).isFalse();

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
@@ -70,7 +70,10 @@ class JavaAssistClassTestDetectionTest {
 		assertThat(classPoolUtil.getClass(ParameterizedTest.class).isATest()).isTrue();
 		assertThat(classPoolUtil.getClass(TestNGFakeProductTest.class).isATest()).isTrue();
 		assertThat(classPoolUtil.getClass(TestNGWithClassLevelOnlyTestAnnotationFakeTest.class).isATest()).isTrue();
-		
+	}
+	
+	@Test
+	void disabledTestShouldBeConsideredAsTests() {
 		// Ignored/disabled tests are still considered as tests, we leave it to the test engine to decide if a test must run
 		// We cannot always evaluate conditions (for instance @DisabledForJreRange)t
 		assertThat(classPoolUtil.getClass(IgnoredClassJUnit4TestCase.class).isATest()).isTrue();

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
@@ -73,10 +73,10 @@ class JavaAssistClassTestDetectionTest {
 		
 		// Ignored/disabled tests are still considered as tests, we leave it to the test engine to decide if a test must run
 		// We cannot always evaluate conditions (for instance @DisabledForJreRange)t
-		assertThat(classPoolUtil.getClass(IgnoredClassJUnit4TestCase.class).isATest()).isFalse();
-		assertThat(classPoolUtil.getClass(IgnoredTestJUnit4TestCase.class).isATest()).isFalse();
-		assertThat(classPoolUtil.getClass(DisabledClassJUnit5TestCase.class).isATest()).isFalse();
-		assertThat(classPoolUtil.getClass(DisabledTestJUnit5TestCase.class).isATest()).isFalse();
+		assertThat(classPoolUtil.getClass(IgnoredClassJUnit4TestCase.class).isATest()).isTrue();
+		assertThat(classPoolUtil.getClass(IgnoredTestJUnit4TestCase.class).isATest()).isTrue();
+		assertThat(classPoolUtil.getClass(DisabledClassJUnit5TestCase.class).isATest()).isTrue();
+		assertThat(classPoolUtil.getClass(DisabledTestJUnit5TestCase.class).isATest()).isTrue();
 	}
 
 	@Test

--- a/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/JavaAssistClassTestDetectionTest.java
@@ -32,7 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fakeco.fakeproduct.DisabledClassJUnit5TestCase;
+import com.fakeco.fakeproduct.DisabledTestJUnit5TestCase;
 import com.fakeco.fakeproduct.FakeProduct;
+import com.fakeco.fakeproduct.IgnoredClassJUnit4TestCase;
+import com.fakeco.fakeproduct.IgnoredTestJUnit4TestCase;
 import com.fakeco.fakeproduct.JUnit3TestThatInherits;
 import com.fakeco.fakeproduct.JUnit4TestThatInherits;
 import com.fakeco.fakeproduct.ParameterizedTest;
@@ -66,6 +70,13 @@ class JavaAssistClassTestDetectionTest {
 		assertThat(classPoolUtil.getClass(ParameterizedTest.class).isATest()).isTrue();
 		assertThat(classPoolUtil.getClass(TestNGFakeProductTest.class).isATest()).isTrue();
 		assertThat(classPoolUtil.getClass(TestNGWithClassLevelOnlyTestAnnotationFakeTest.class).isATest()).isTrue();
+		
+		// Ignored/disabled tests are still considered as tests, we leave it to the test engine to decide if a test much run
+		// We cannot always evaluate conditions (for instance @DisabledForJreRange)t
+		assertThat(classPoolUtil.getClass(IgnoredClassJUnit4TestCase.class).isATest()).isFalse();
+		assertThat(classPoolUtil.getClass(IgnoredTestJUnit4TestCase.class).isATest()).isFalse();
+		assertThat(classPoolUtil.getClass(DisabledClassJUnit5TestCase.class).isATest()).isFalse();
+		assertThat(classPoolUtil.getClass(DisabledTestJUnit5TestCase.class).isATest()).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
Slow test markers are only updated for test that have been executed. In case a test method was removed or disabled we should remove the marker

Fixes #142