### PR TITLE
Upgrade from JDK 8 to JDK 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '19' ]
+        java: [ '11', '17', '19' ]
     name: Unit tests Java ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3
@@ -25,13 +25,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gtk2.0 libxtst6
-      - name: Build and Test Java 8
-        if: ${{ matrix.Java == '8' }}
-      # We need a virtual X11 for the Eclipse unit tests
-        run: |
-          xvfb-run -a mvn -B test -pl infinitest-lib,infinitest-runner -am
-      - name: Build and Test Java > 8
-        if: ${{ matrix.Java != '8' }}
+      - name: Build and Test
       # We need a virtual X11 for the Eclipse unit tests
         run: |
           xvfb-run -a mvn -B package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You can pull only a shallow clone by specifying the number of commits you want w
 
 ## Build
 
-Infinitest is on Java 8, except for the `infinitest-intellij` module which is on Java 11, so a JDK >= 11 is required for building.
+Infinitest requires JDK 11 or above.
 You need [Maven](http://maven.apache.org/download.html). To run a reactor build in the repository root: 
 
 	mvn clean install

--- a/infinitest-intellij/pom.xml
+++ b/infinitest-intellij/pom.xml
@@ -14,8 +14,6 @@
     <intellij.version>20.1.0</intellij.version>
     <intellij.api.version>221.5787.30</intellij.api.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 
 		<javassist.version>3.29.2-GA</javassist.version>
 		<mockito.version>4.7.0</mockito.version>


### PR DESCRIPTION
#431 upgrades to TestNG which requires JDK 11