### PR TITLE
Add JDK 21 to the matrix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '19' ]
+        java: [ '11', '17', '21' ]
     name: Unit tests Java ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3

--- a/functional-tests/infinitest-runner-spock-test/pom.xml
+++ b/functional-tests/infinitest-runner-spock-test/pom.xml
@@ -12,7 +12,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <spock.version>2.3-groovy-4.0</spock.version>
+    <spock.version>2.4-M5-groovy-4.0</spock.version>
   </properties>
 
   <build>

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -174,7 +174,7 @@ public class IntellijMockBase {
 		
 		// Setup the properties component
 		PropertiesComponent propertiesComponent = mock(PropertiesComponent.class);
-		when(propertiesComponent.getValue("power.save.mode")).thenReturn(Boolean.toString(powerSaveModeEnabled));
+		when(propertiesComponent.getBoolean("power.save.mode")).thenReturn(Boolean.valueOf(powerSaveModeEnabled));
 		
 		when(application.getService(PropertiesComponent.class)).thenReturn(propertiesComponent);
 		

--- a/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
+++ b/infinitest-intellij/src/test/java/org/infinitest/intellij/IntellijMockBase.java
@@ -174,7 +174,7 @@ public class IntellijMockBase {
 		
 		// Setup the properties component
 		PropertiesComponent propertiesComponent = mock(PropertiesComponent.class);
-		when(propertiesComponent.getBoolean("power.save.mode")).thenReturn(Boolean.valueOf(powerSaveModeEnabled));
+		when(propertiesComponent.getBoolean("power.save.mode")).thenReturn(powerSaveModeEnabled);
 		
 		when(application.getService(PropertiesComponent.class)).thenReturn(propertiesComponent);
 		

--- a/infinitest-lib/src/test/java/org/infinitest/parser/WhenLookingForDependenciesBetweenClasses.java
+++ b/infinitest-lib/src/test/java/org/infinitest/parser/WhenLookingForDependenciesBetweenClasses.java
@@ -131,11 +131,11 @@ class WhenLookingForDependenciesBetweenClasses extends DependencyGraphTestBase {
   void shouldFindNewlyCreatedClasses() throws Exception {
     ClassPool pool = ClassPool.getDefault();
     pool.appendPathList(systemClasspath());
-    CtClass cc = pool.makeClass("ANewTest");
+    CtClass cc = pool.makeClass("org.infinitest.parser.ANewTest");
     cc.setSuperclass(pool.get(TestCase.class.getName()));
     cc.addMethod(CtMethod.make("void testSomething(){}", cc));
     cc.writeFile(FakeEnvironments.fakeClassDirectory().getAbsolutePath());
-    Class<?> testClass = cc.toClass();
+    Class<?> testClass = cc.toClass(getClass());
     InfinitestTestUtils.getFileForClass(testClass).deleteOnExit();
     assertClassRecognizedAsTest(testClass);
   }

--- a/infinitest-runner-test/pom.xml
+++ b/infinitest-runner-test/pom.xml
@@ -10,8 +10,10 @@
 
 	<properties>
 		<user.junit.version>5.8.2</user.junit.version>
+		<user.junit5-platform.version>1.8.2</user.junit5-platform.version>
 		<user.assertj.version>3.23.1</user.assertj.version>
 		<user.hamcrest.version>3.23.1</user.hamcrest.version>
+		<user.surefire.version>3.0.0-M7</user.surefire.version>
 	</properties>
 
 	<dependencies>
@@ -32,6 +34,13 @@
 			<artifactId>junit-jupiter-params</artifactId>
 			<version>${user.junit.version}</version>
 			<scope>test</scope>
+		</dependency>
+		
+		<!-- Overriden here so we don't get the version from infinitest-runner -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>${user.junit5-platform.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -55,26 +64,13 @@
 		</dependency>
 	</dependencies>
 
-	<!--
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>infinitest-runner-test</id>
-						<phase>test</phase>
-						<goals>
-							<goal>test</goal>
-						</goals>
-						<configuration>
-							<testClassesDirectory>${project.basedir}/../infinitest-lib/target/test-classes</testClassesDirectory>
-							<testClassesDirectory>${project.basedir}/../infinitest-runner/target/test-classes</testClassesDirectory>
-						</configuration>
-					</execution>
-				</executions>
+				<version>${user.surefire.version}</version>
 			</plugin>
 		</plugins>
 	</build>
-	-->
 </project>

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/junit5/JUnit5EventTranslatorTest.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/junit5/JUnit5EventTranslatorTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.opentest4j.AssertionFailedError;
@@ -59,13 +60,18 @@ class JUnit5EventTranslatorTest {
 	void before() throws NoSuchMethodException, SecurityException {
 		stubClock = new StubClock();
 		eventTranslator = new JUnit5EventTranslator(stubClock);
-		ConfigurationParameters parameters = LauncherDiscoveryRequestBuilder.request().build().getConfigurationParameters(); 
+		LauncherDiscoveryRequest launcherDiscovery = LauncherDiscoveryRequestBuilder.request().build();
+		ConfigurationParameters parameters = launcherDiscovery.getConfigurationParameters(); 
+		
 		JupiterConfiguration configuration = new DefaultJupiterConfiguration(parameters);
 
 		UniqueId id = UniqueId.parse(
 				"[engine:junit-jupiter]/[class:org.infinitest.testrunner.exampletests.junit5.JUnit5Test]/[method:shouldFail()]");
-		shouldFailMethodTestDescriptor = new TestMethodTestDescriptor(id, JUnit5Test.class,
-				JUnit5Test.class.getMethod("shouldFail"), configuration);
+		shouldFailMethodTestDescriptor = new TestMethodTestDescriptor(
+				id,
+				JUnit5Test.class,
+				JUnit5Test.class.getMethod("shouldFail"),
+				configuration);
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-		<javassist.version>3.29.2-GA</javassist.version>
-		<mockito.version>4.7.0</mockito.version>
+		<javassist.version>3.30.2-GA</javassist.version>
+		<mockito.version>5.15.2</mockito.version>
 		<junit.version>4.12</junit.version>
-		<junit5.version>5.9.1</junit5.version>
-		<junit5-platform.version>1.9.1</junit5-platform.version>
+		<junit5.version>5.11.4</junit5.version>
+		<junit5-platform.version>1.11.4</junit5-platform.version>
 		<archunit-junit5.version>1.0.0</archunit-junit5.version>
 		<guava.version>18.0</guava.version>
 		<hamcrest.version>1.3</hamcrest.version>
@@ -41,7 +41,7 @@
 		<assertj.version>3.11.1</assertj.version>
 		<autovalue.version>1.3</autovalue.version>
 		<jcommander.version>1.35</jcommander.version>
-		<surefire.version>3.0.0-M7</surefire.version>
+		<surefire.version>3.4.0</surefire.version>
 		<awaitility.version>4.2.0</awaitility.version>
 		
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -208,7 +208,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.8</version>
+					<version>0.8.12</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
Upgrade dependencies to make the build compatible with JDK 21:
- Mockito
- JUnit
- Javassist
- Jacoco
- Groovy
- Surefire

Align test libraries versions with Mockito's latest version (since Mockito doesn't support yet the latest JUnit)