### PR TITLE
Handle the case when the test class failed to initialize

### DIFF
--- a/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerInfo.java
+++ b/infinitest-eclipse/src/main/java/org/infinitest/eclipse/markers/ProblemMarkerInfo.java
@@ -39,6 +39,7 @@ import org.eclipse.core.resources.*;
 import org.eclipse.core.runtime.*;
 import org.infinitest.eclipse.workspace.*;
 import org.infinitest.testrunner.*;
+import org.infinitest.testrunner.TestEvent.TestState;
 
 public class ProblemMarkerInfo extends AbstractMarkerInfo {
 	public static final String PICKLED_STACK_TRACE_ATTRIBUTE = "Pickled Stack Trace";
@@ -108,7 +109,13 @@ public class ProblemMarkerInfo extends AbstractMarkerInfo {
 
 	private String buildMessage(TestEvent anEvent) {
 		PointOfFailure failure = anEvent.getPointOfFailure();
-		return anEvent.getErrorClassName() + getMessage(failure) + " in " + stripPackageName(event.getTestName()) + "." + anEvent.getTestMethod();
+		String message = anEvent.getErrorClassName() + getMessage(failure) + " in " + stripPackageName(event.getTestName()) + "." + anEvent.getTestMethod();
+		
+		if (anEvent.getType() == TestState.TEST_INITIALIZATION_FAILURE) {
+			return message + "\n\n" + anEvent.getPrintedStackTrace();
+		} else {
+			return message;
+		}
 	}
 
 	private String getMessage(PointOfFailure failure) {

--- a/infinitest-runner/src/main/java/org/infinitest/TestClassInitializationException.java
+++ b/infinitest-runner/src/main/java/org/infinitest/TestClassInitializationException.java
@@ -1,0 +1,39 @@
+/*
+ * Infinitest, a Continuous Test Runner.
+ *
+ * Copyright (C) 2010-2013
+ * "Ben Rady" <benrady@gmail.com>,
+ * "Rod Coffin" <rfciii@gmail.com>,
+ * "Ryan Breidenbach" <ryan.breidenbach@gmail.com>
+ * "David Gageot" <david@gageot.net>, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.infinitest;
+
+/**
+ * 
+ */
+public class TestClassInitializationException extends RuntimeException {
+	private static final long serialVersionUID = 8140038711792655496L;
+
+	public TestClassInitializationException(String message, Throwable t) {
+		super(message, t);
+	}
+}

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/DefaultRunner.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/DefaultRunner.java
@@ -28,6 +28,7 @@
 package org.infinitest.testrunner;
 
 import org.infinitest.MissingClassException;
+import org.infinitest.TestClassInitializationException;
 import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 import org.infinitest.config.InfinitestConfigurationSource;
 import org.infinitest.testrunner.junit4.Junit4And3Runner;
@@ -55,6 +56,8 @@ public class DefaultRunner implements NativeRunner {
 			testClass = Class.forName(testClassName);
 		} catch (ClassNotFoundException e) {
 			throw new MissingClassException(testClassName);
+		} catch (Throwable t) {
+			throw new TestClassInitializationException("Failed to initialize test class " + testClassName, t);
 		}
 
 		if (TestNgRunner.isTestNGTest(testClass)) {

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/TestEvent.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/TestEvent.java
@@ -35,6 +35,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+import org.infinitest.MissingClassException;
+
 /**
  * @author <a href="mailto:benrady@gmail.com">Ben Rady</a>
  */
@@ -100,7 +102,7 @@ public class TestEvent implements Serializable {
 			
 			printedStackTrace = out.toString(StandardCharsets.UTF_8);
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new MissingClassException("Error when trying to print stack trace", e);
 		}
 		
 		simpleErrorClassName = error.getClass().getSimpleName();

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
@@ -28,6 +28,7 @@
 package org.infinitest.testrunner;
 
 import static org.infinitest.testrunner.TestEvent.methodFailed;
+import static org.infinitest.testrunner.TestEvent.testInitializationFailed;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -37,6 +38,7 @@ import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
+import org.infinitest.TestClassInitializationException;
 import org.infinitest.config.FileBasedInfinitestConfigurationSource;
 
 // RISK This class is only tested by running it, which is slow and throws off coverage
@@ -135,13 +137,12 @@ public class TestRunnerProcess {
 		TestResults results;
 		try {
 			results = process.runTest(testName);
-		}
-		// CHECKSTYLE:OFF
-		catch (Throwable e)
-		// CHECKSTYLE:ON
-		{
+		} catch (TestClassInitializationException e) {
+			results = new TestResults(testInitializationFailed(testName, "", e));
+		} catch (Throwable e) {
 			results = new TestResults(methodFailed(testName, "", e));
 		}
+		
 		outputStream.writeObject(results);
 	}
 }

--- a/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
+++ b/infinitest-runner/src/main/java/org/infinitest/testrunner/TestRunnerProcess.java
@@ -133,7 +133,7 @@ public class TestRunnerProcess {
 		}
 	}
 
-	private static void writeTestResultToOutputStream(TestRunnerProcess process, ObjectOutputStream outputStream, String testName) throws IOException {
+	public static void writeTestResultToOutputStream(TestRunnerProcess process, ObjectOutputStream outputStream, String testName) throws IOException {
 		TestResults results;
 		try {
 			results = process.runTest(testName);

--- a/infinitest-runner/src/test/java/org/infinitest/testrunner/TestRunnerProcessTest.java
+++ b/infinitest-runner/src/test/java/org/infinitest/testrunner/TestRunnerProcessTest.java
@@ -45,8 +45,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import javax.management.RuntimeErrorException;
-
 import org.infinitest.testrunner.TestEvent.TestState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;


### PR DESCRIPTION
Sometimes the test class does not load, for instance when JMockit's agent was not loaded. In that case we want to show the full stacktrace, including the cause(s) exception(s).
This should fix #434 